### PR TITLE
fix: Materialize parsed route early to avoid "Collection was modified" exceptions

### DIFF
--- a/source/Maestro.Plugin/Plugin.cs
+++ b/source/Maestro.Plugin/Plugin.cs
@@ -361,6 +361,7 @@ public class Plugin : IPlugin
             return;
 
         var estimates = updated.ParsedRoute
+            .ToArray() // Materialize to avoid mutation during enumeration
             .Select((s, i) => new FixEstimate(
                 s.Intersection.Name,
                 ToDateTimeOffset(s.ETO),


### PR DESCRIPTION
Fixes https://github.com/YuKitsune/vMaestro/issues/21