### PR TITLE
fix(Server): Fix connection initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ node_modules
 npm-debug.log
 
 .env
+
+# Debugging 
+logs/

--- a/source/Maestro.Core.Tests/Fixtures/AirportConfigurationFixture.cs
+++ b/source/Maestro.Core.Tests/Fixtures/AirportConfigurationFixture.cs
@@ -126,7 +126,8 @@ public class AirportConfigurationFixture
                     Identifier = "BIK",
                     LeftLadder = [],
                     RightLadder = [],
-                    ViewMode = ViewMode.Enroute
+                    ViewMode = ViewMode.Enroute,
+                    TimeHorizonMinutes = 45
                 }
             ],
             FeederFixes = ["RIVET", "WELSH", "BOREE", "YAKKA", "MARLN"],

--- a/source/Maestro.Core/Connectivity/Contracts/ConnectionInitializedNotification.cs
+++ b/source/Maestro.Core/Connectivity/Contracts/ConnectionInitializedNotification.cs
@@ -9,4 +9,4 @@ public record ConnectionInitializedNotification(
     string AirportIdentifier,
     bool IsMaster,
     SessionMessage? Session,
-    IReadOnlyList<PeerInfo> ConnectedPeers) : INotification;
+    PeerInfo[] ConnectedPeers) : INotification;

--- a/source/Maestro.Core/Connectivity/Contracts/InitializeConnectionRequest.cs
+++ b/source/Maestro.Core/Connectivity/Contracts/InitializeConnectionRequest.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace Maestro.Core.Connectivity.Contracts;
+
+public record InitializeConnectionRequest : IRequest<InitializeConnectionResponse>;

--- a/source/Maestro.Core/Connectivity/Contracts/InitializeConnectionResponse.cs
+++ b/source/Maestro.Core/Connectivity/Contracts/InitializeConnectionResponse.cs
@@ -1,0 +1,11 @@
+using Maestro.Core.Sessions;
+
+namespace Maestro.Core.Connectivity.Contracts;
+
+public record InitializeConnectionResponse(
+    string ConnectionId,
+    string Partition,
+    string AirportIdentifier,
+    bool IsMaster,
+    SessionMessage? Session,
+    PeerInfo[] ConnectedPeers);

--- a/source/Maestro.Server.Tests/InitializeConnectionRequestHandlerTests.cs
+++ b/source/Maestro.Server.Tests/InitializeConnectionRequestHandlerTests.cs
@@ -1,0 +1,147 @@
+using Maestro.Core.Connectivity.Contracts;
+using Maestro.Core.Messages;
+using Maestro.Core.Sessions;
+using Maestro.Server.Handlers;
+using Moq;
+using Shouldly;
+using ILogger = Serilog.ILogger;
+
+namespace Maestro.Server.Tests;
+
+public class InitializeConnectionRequestHandlerTests
+{
+    const string Version = "0.0.0";
+
+    [Fact]
+    public async Task ReturnsConnectionInitializationData()
+    {
+        // Arrange
+        const string connectionId = "connection-1";
+        const string partition = "partition-1";
+        const string airportIdentifier = "YSSY";
+        const string callsign = "ML-BIK_CTR";
+        const Role role = Role.Enroute;
+
+        var connection = new Connection(connectionId, Version, partition, airportIdentifier, callsign, role) { IsMaster = true };
+
+        var connectionManager = new Mock<IConnectionManager>();
+        connectionManager.Setup(x => x.TryGetConnection(connectionId, out connection)).Returns(true);
+        connectionManager.Setup(x => x.GetConnections(partition, airportIdentifier)).Returns([connection]);
+
+        var request = new InitializeConnectionRequest();
+        var wrappedRequest = new RequestContextWrapper<InitializeConnectionRequest, InitializeConnectionResponse>(connectionId, request);
+
+        // Act
+        var response = await GetHandler(connectionManager: connectionManager.Object)
+            .Handle(wrappedRequest, CancellationToken.None);
+
+        // Assert
+        response.ConnectionId.ShouldBe(connectionId);
+        response.Partition.ShouldBe(partition);
+        response.AirportIdentifier.ShouldBe(airportIdentifier);
+        response.IsMaster.ShouldBeTrue();
+        response.ConnectedPeers.ShouldBeEmpty();
+        response.Session.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsConnectedPeers()
+    {
+        // Arrange
+        const string connectionId = "connection-2";
+        const string partition = "partition-1";
+        const string airportIdentifier = "YSSY";
+
+        var connection1 = new Connection("connection-1", Version, partition, airportIdentifier, "SY_APP", Role.Approach) { IsMaster = true };
+        var connection2 = new Connection(connectionId, Version, partition, airportIdentifier, "ML-BIK_CTR", Role.Enroute);
+
+        var connectionManager = new Mock<IConnectionManager>();
+        connectionManager.Setup(x => x.TryGetConnection(connectionId, out connection2)).Returns(true);
+        connectionManager.Setup(x => x.GetConnections(partition, airportIdentifier)).Returns([connection1, connection2]);
+
+        var request = new InitializeConnectionRequest();
+        var wrappedRequest = new RequestContextWrapper<InitializeConnectionRequest, InitializeConnectionResponse>(connectionId, request);
+
+        // Act
+        var response = await GetHandler(connectionManager: connectionManager.Object)
+            .Handle(wrappedRequest, CancellationToken.None);
+
+        // Assert
+        response.ConnectedPeers.Length.ShouldBe(1);
+        response.ConnectedPeers[0].Callsign.ShouldBe("SY_APP");
+        response.ConnectedPeers[0].Role.ShouldBe(Role.Approach);
+    }
+
+    [Fact]
+    public async Task ReturnsCachedSession()
+    {
+        // Arrange
+        const string connectionId = "connection-1";
+        const string partition = "partition-1";
+        const string airportIdentifier = "YSSY";
+
+        var connection = new Connection(connectionId, Version, partition, airportIdentifier, "ML-BIK_CTR", Role.Enroute) { IsMaster = true };
+        var cachedSession = new SessionMessage
+        {
+            AirportIdentifier = airportIdentifier,
+            PendingFlights = [],
+            DeSequencedFlights = [],
+            DummyCounter = 0,
+            Sequence = new SequenceMessage
+            {
+                CurrentRunwayMode = null,
+                NextRunwayMode = null,
+                LastLandingTimeForCurrentMode = default,
+                FirstLandingTimeForNextMode = default,
+                Flights = [],
+                Slots = [],
+            }
+        };
+
+        var connectionManager = new Mock<IConnectionManager>();
+        connectionManager.Setup(x => x.TryGetConnection(connectionId, out connection)).Returns(true);
+        connectionManager.Setup(x => x.GetConnections(partition, airportIdentifier)).Returns([connection]);
+
+        var sessionCache = new SessionCache();
+        sessionCache.Set(partition, airportIdentifier, cachedSession);
+
+        var request = new InitializeConnectionRequest();
+        var wrappedRequest = new RequestContextWrapper<InitializeConnectionRequest, InitializeConnectionResponse>(connectionId, request);
+
+        // Act
+        var response = await GetHandler(connectionManager.Object, sessionCache)
+            .Handle(wrappedRequest, CancellationToken.None);
+
+        // Assert
+        response.Session.ShouldBe(cachedSession);
+    }
+
+    [Fact]
+    public async Task ThrowsWhenConnectionNotFound()
+    {
+        // Arrange
+        const string connectionId = "connection-1";
+        Connection? connection = null;
+
+        var connectionManager = new Mock<IConnectionManager>();
+        connectionManager.Setup(x => x.TryGetConnection(connectionId, out connection)).Returns(false);
+
+        var request = new InitializeConnectionRequest();
+        var wrappedRequest = new RequestContextWrapper<InitializeConnectionRequest, InitializeConnectionResponse>(connectionId, request);
+
+        // Act & Assert
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await GetHandler(connectionManager: connectionManager.Object)
+                .Handle(wrappedRequest, CancellationToken.None));
+    }
+
+    InitializeConnectionRequestHandler GetHandler(
+        IConnectionManager? connectionManager = null,
+        SessionCache? sessionCache = null)
+    {
+        connectionManager ??= new Mock<IConnectionManager>().Object;
+        sessionCache ??= new SessionCache();
+        var logger = new Mock<ILogger>().Object;
+        return new InitializeConnectionRequestHandler(connectionManager, sessionCache, logger);
+    }
+}

--- a/source/Maestro.Server.Tests/SessionUpdatedNotificationHandlerTests.cs
+++ b/source/Maestro.Server.Tests/SessionUpdatedNotificationHandlerTests.cs
@@ -208,13 +208,13 @@ public class SessionUpdatedNotificationHandlerTests
 
         hubProxy.Verify(x => x.Send(
             peer1.Id,
-            "SequenceUpdated",
+            "SessionUpdated",
             sessionUpdatedNotification,
             It.IsAny<CancellationToken>()), Times.Once);
 
         hubProxy.Verify(x => x.Send(
             peer2.Id,
-            "SequenceUpdated",
+            "SessionUpdated",
             sessionUpdatedNotification,
             It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/source/Maestro.Server/Handlers/ConnectRequestHandler.cs
+++ b/source/Maestro.Server/Handlers/ConnectRequestHandler.cs
@@ -70,19 +70,5 @@ public class ConnectRequestHandler(
                 new PeerConnectedNotification(request.AirportIdentifier, request.Callsign, request.Role),
                 cancellationToken);
         }
-
-        var latestSequence = sessionCache.Get(request.Partition, request.AirportIdentifier);
-
-        await hubProxy.Send(
-            connectionId,
-            "ConnectionInitialized",
-            new ConnectionInitializedNotification(
-                connectionId,
-                request.Partition,
-                request.AirportIdentifier,
-                connection.IsMaster,
-                latestSequence,
-                peers.Select(c => new PeerInfo(c.Callsign, c.Role)).ToArray()),
-            cancellationToken);
     }
 }

--- a/source/Maestro.Server/Handlers/InitializeConnectionRequestHandler.cs
+++ b/source/Maestro.Server/Handlers/InitializeConnectionRequestHandler.cs
@@ -1,0 +1,38 @@
+using Maestro.Core.Connectivity.Contracts;
+using MediatR;
+using ILogger = Serilog.ILogger;
+
+namespace Maestro.Server.Handlers;
+
+public class InitializeConnectionRequestHandler(
+    IConnectionManager connectionManager,
+    SessionCache sessionCache,
+    ILogger logger)
+    : IRequestHandler<RequestContextWrapper<InitializeConnectionRequest, InitializeConnectionResponse>, InitializeConnectionResponse>
+{
+    public Task<InitializeConnectionResponse> Handle(
+        RequestContextWrapper<InitializeConnectionRequest, InitializeConnectionResponse> wrappedRequest,
+        CancellationToken cancellationToken)
+    {
+        var connectionId = wrappedRequest.ConnectionId;
+
+        if (!connectionManager.TryGetConnection(connectionId, out var connection))
+            throw new InvalidOperationException($"Connection {connectionId} not found");
+
+        var peers = connectionManager.GetConnections(connection.Partition, connection.AirportIdentifier)
+            .Where(c => c.Id != connectionId)
+            .ToArray();
+
+        var latestSequence = sessionCache.Get(connection.Partition, connection.AirportIdentifier);
+
+        logger.Information("Client {ConnectionId} ({Callsign}) requesting initialization", connectionId, connection.Callsign);
+
+        return Task.FromResult(new InitializeConnectionResponse(
+            connectionId,
+            connection.Partition,
+            connection.AirportIdentifier,
+            connection.IsMaster,
+            latestSequence,
+            peers.Select(c => new PeerInfo(c.Callsign, c.Role)).ToArray()));
+    }
+}

--- a/source/Maestro.Server/MaestroHub.cs
+++ b/source/Maestro.Server/MaestroHub.cs
@@ -13,6 +13,14 @@ public class MaestroHub(IMediator mediator, ILogger logger) : Hub
 {
     static readonly string ServerVersion = AssemblyVersionHelper.GetVersion(typeof(MaestroHub).Assembly);
 
+    public async Task<InitializeConnectionResponse> InitializeConnection(InitializeConnectionRequest request)
+    {
+        return await mediator.Send(
+            new RequestContextWrapper<InitializeConnectionRequest, InitializeConnectionResponse>(
+                Context.ConnectionId,
+                request));
+    }
+
     public async Task SessionUpdated(SessionUpdatedNotification sessionUpdatedNotification)
     {
         await mediator.Publish(new NotificationContextWrapper<SessionUpdatedNotification>(Context.ConnectionId, sessionUpdatedNotification));


### PR DESCRIPTION
Fixed an issue where connection initialization would fail due to timing during the connection phase.
Connections are now initialized by invoking the `InitializeConnection` method on the server.