### PR TITLE
fix(tools): support space-separated waypoints in STAR routes

### DIFF
--- a/source/Maestro.Tools/Commands/ExtractStarsCommand.cs
+++ b/source/Maestro.Tools/Commands/ExtractStarsCommand.cs
@@ -84,14 +84,14 @@ public static class ExtractStarsCommand
                 if (string.IsNullOrEmpty(routeText))
                     continue;
 
-                var routeWaypoints = routeText.Split('/');
+                var routeWaypoints = routeText.Split(['/', ' '], StringSplitOptions.RemoveEmptyEntries);
                 if (transitions.Count > 0)
                 {
                     // One trajectory per transition × route combination.
                     // The transition name is the feeder fix; the first route waypoint is the transition fix.
                     foreach (var transition in transitions)
                     {
-                        var transitionWaypoints = transition.Value.Trim().Split('/');
+                        var transitionWaypoints = transition.Value.Trim().Split(['/', ' '], StringSplitOptions.RemoveEmptyEntries);
                         if (transitionWaypoints.Length == 0)
                             continue;
 


### PR DESCRIPTION
Support waypoints separated by spaces (in addition to `/`) when parsing STAR and transition routes in `extract-stars`.

Closes #131