### PR TITLE
Highlight flight labels designated in vatSys

### DIFF
--- a/source/Maestro.Plugin/Plugin.cs
+++ b/source/Maestro.Plugin/Plugin.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Messaging;
 using Maestro.Contracts.Flights;
 using Maestro.Contracts.Shared;
 using Maestro.Core;
@@ -17,6 +18,7 @@ using Maestro.Plugin.Configuration;
 using Maestro.Plugin.Handlers;
 using Maestro.Plugin.Infrastructure;
 using Maestro.Wpf;
+using Maestro.Wpf.Contracts;
 using Maestro.Wpf.Integrations;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -65,6 +67,8 @@ public class Plugin : IPlugin
             Network.Connected += NetworkOnConnected;
             Network.Disconnected += NetworkOnDisconnected;
 
+            MMI.SelectedTrackChanged += SelectedTrackChanged;
+
             var executingAssembly = Assembly.GetExecutingAssembly();
             var version = executingAssembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
@@ -88,6 +92,13 @@ public class Plugin : IPlugin
             Errors.Add(ex, Name);
             _logger?.Error(ex, "An error occurred during initialization.");
         }
+    }
+
+    void SelectedTrackChanged(object sender, EventArgs e)
+    {
+        var selectedTrack = MMI.SelectedTrack;
+        var callsign = selectedTrack?.GetFDR()?.Callsign;
+        WeakReferenceMessenger.Default.Send(new TrackSelectedMessage(callsign));
     }
 
     void ConfigureTheme()

--- a/source/Maestro.Plugin/Plugin.cs
+++ b/source/Maestro.Plugin/Plugin.cs
@@ -98,7 +98,7 @@ public class Plugin : IPlugin
     {
         var selectedTrack = MMI.SelectedTrack;
         var callsign = selectedTrack?.GetFDR()?.Callsign;
-        WeakReferenceMessenger.Default.Send(new TrackSelectedMessage(callsign));
+        WeakReferenceMessenger.Default.Send(new VatsysTrackSelectedNotification(callsign));
     }
 
     void ConfigureTheme()

--- a/source/Maestro.Wpf/Contracts/TrackSelectedMessage.cs
+++ b/source/Maestro.Wpf/Contracts/TrackSelectedMessage.cs
@@ -1,0 +1,3 @@
+namespace Maestro.Wpf.Contracts;
+
+public record TrackSelectedMessage(string? Callsign);

--- a/source/Maestro.Wpf/Contracts/TrackSelectedMessage.cs
+++ b/source/Maestro.Wpf/Contracts/TrackSelectedMessage.cs
@@ -1,3 +1,0 @@
-namespace Maestro.Wpf.Contracts;
-
-public record TrackSelectedMessage(string? Callsign);

--- a/source/Maestro.Wpf/Contracts/VatsysTrackSelectedNotification.cs
+++ b/source/Maestro.Wpf/Contracts/VatsysTrackSelectedNotification.cs
@@ -1,0 +1,3 @@
+namespace Maestro.Wpf.Contracts;
+
+public record VatsysTrackSelectedNotification(string? Callsign);

--- a/source/Maestro.Wpf/ViewModels/FlightLabelViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/FlightLabelViewModel.cs
@@ -8,7 +8,6 @@ using CommunityToolkit.Mvvm.Messaging;
 using Maestro.Contracts.Flights;
 using Maestro.Contracts.Shared;
 using Maestro.Core.Configuration;
-using Maestro.Core.Model;
 using Maestro.Wpf.Contracts;
 using Maestro.Wpf.Integrations;
 using MediatR;
@@ -16,7 +15,7 @@ using Color = Maestro.Core.Configuration.Color;
 
 namespace Maestro.Wpf.ViewModels;
 
-public partial class FlightLabelViewModel : ObservableObject
+public partial class FlightLabelViewModel : ObservableObject, IRecipient<VatsysTrackSelectedNotification>
 {
     const string None = "NONE";
 
@@ -375,8 +374,12 @@ public partial class FlightLabelViewModel : ObservableObject
         _flightViewModel = flightViewModel;
         _isVatsysTrackSelected = vatsysSelectedTrackCallsign == flightViewModel.Callsign;
 
-        WeakReferenceMessenger.Default.Register<VatsysTrackSelectedNotification>(this, (_, m) =>
-            IsVatsysTrackSelected = m.Callsign == FlightViewModel.Callsign);
+        WeakReferenceMessenger.Default.Register(this);
+    }
+
+    public void Receive(VatsysTrackSelectedNotification message)
+    {
+        IsVatsysTrackSelected = message.Callsign == FlightViewModel.Callsign;
     }
 
     public void UpdateLabelItems(LabelLayoutConfiguration labelLayout, FlightDto flight, int ladderIndex)

--- a/source/Maestro.Wpf/ViewModels/FlightLabelViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/FlightLabelViewModel.cs
@@ -363,7 +363,8 @@ public partial class FlightLabelViewModel : ObservableObject
         GlobalColourConfiguration globalColorConfiguration,
         FlightDto flightViewModel,
         string[] availableRunways,
-        string[] availableApproachTypes)
+        string[] availableApproachTypes,
+        string? vatsysSelectedTrackCallsign = null)
     {
         _mediator = mediator;
         _errorReporter = errorReporter;
@@ -372,8 +373,9 @@ public partial class FlightLabelViewModel : ObservableObject
         _availableRunways = availableRunways;
         _availableApproachTypes = availableApproachTypes;
         _flightViewModel = flightViewModel;
+        _isVatsysTrackSelected = vatsysSelectedTrackCallsign == flightViewModel.Callsign;
 
-        WeakReferenceMessenger.Default.Register<TrackSelectedMessage>(this, (_, m) =>
+        WeakReferenceMessenger.Default.Register<VatsysTrackSelectedNotification>(this, (_, m) =>
             IsVatsysTrackSelected = m.Callsign == FlightViewModel.Callsign);
     }
 

--- a/source/Maestro.Wpf/ViewModels/FlightLabelViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/FlightLabelViewModel.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Maestro.Contracts.Flights;
 using Maestro.Contracts.Shared;
 using Maestro.Core.Configuration;
@@ -15,15 +16,7 @@ using Color = Maestro.Core.Configuration.Color;
 
 namespace Maestro.Wpf.ViewModels;
 
-public partial class FlightLabelViewModel(
-    IMediator mediator,
-    IErrorReporter errorReporter,
-    MaestroViewModel maestroViewModel,
-    GlobalColourConfiguration globalColorConfiguration,
-    FlightDto flightViewModel,
-    string[] availableRunways,
-    string[] availableApproachTypes)
-    : ObservableObject
+public partial class FlightLabelViewModel : ObservableObject
 {
     const string None = "NONE";
 
@@ -33,16 +26,19 @@ public partial class FlightLabelViewModel(
     [NotifyPropertyChangedFor(nameof(CanChangeApproachType))]
     [NotifyPropertyChangedFor(nameof(Indicators))]
     [NotifyCanExecuteChangedFor(nameof(ShowInformationWindowCommand))]
-    FlightDto _flightViewModel = flightViewModel;
+    FlightDto _flightViewModel;
 
     [ObservableProperty]
     bool _isSelected = false;
 
+    [ObservableProperty]
+    bool _isVatsysTrackSelected = false;
+
     public string Indicators => BuildIndicators();
 
-    public string[] AvailableRunways => availableRunways.Where(r => r != FlightViewModel.AssignedRunwayIdentifier).ToArray();
+    public string[] AvailableRunways => _availableRunways.Where(r => r != FlightViewModel.AssignedRunwayIdentifier).ToArray();
 
-    public string[] AvailableApproachTypes => availableApproachTypes.Where(a => a != FlightViewModel.ApproachType).ToArray();
+    public string[] AvailableApproachTypes => _availableApproachTypes.Where(a => a != FlightViewModel.ApproachType).ToArray();
 
     public bool CanChangeApproachType => AvailableApproachTypes.Any();
 
@@ -94,11 +90,11 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(new OpenInformationWindowRequest(FlightViewModel));
+            _mediator.Send(new OpenInformationWindowRequest(FlightViewModel));
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -112,13 +108,13 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(
+            _mediator.Send(
                 new RecomputeRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign),
                 CancellationToken.None);
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -132,13 +128,13 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(
+            _mediator.Send(
                 new ChangeRunwayRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign, runwayIdentifier),
                 CancellationToken.None);
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -150,13 +146,13 @@ public partial class FlightLabelViewModel(
             if (approachType == None)
                 approachType = string.Empty;
 
-            mediator.Send(
+            _mediator.Send(
                 new ChangeApproachTypeRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign, approachType),
                 CancellationToken.None);
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -165,16 +161,16 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(
+            _mediator.Send(
                 new OpenInsertFlightWindowRequest(
                     FlightViewModel.DestinationIdentifier,
                     new RelativeInsertionOptions(FlightViewModel.Callsign, RelativePosition.Before),
-                    maestroViewModel.Flights.Where(f => f.State == State.Landed).ToArray(),
-                    maestroViewModel.PendingFlights.ToArray()));
+                    _maestroViewModel.Flights.Where(f => f.State == State.Landed).ToArray(),
+                    _maestroViewModel.PendingFlights.ToArray()));
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -188,16 +184,16 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(
+            _mediator.Send(
                 new OpenInsertFlightWindowRequest(
                     FlightViewModel.DestinationIdentifier,
                     new RelativeInsertionOptions(FlightViewModel.Callsign, RelativePosition.After),
-                    maestroViewModel.Flights.Where(f => f.State == State.Landed).ToArray(),
-                    maestroViewModel.PendingFlights.ToArray()));
+                    _maestroViewModel.Flights.Where(f => f.State == State.Landed).ToArray(),
+                    _maestroViewModel.PendingFlights.ToArray()));
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -210,7 +206,7 @@ public partial class FlightLabelViewModel(
                 ? [FlightViewModel.AssignedRunwayIdentifier]
                 : Array.Empty<string>();
 
-            mediator.Send(
+            _mediator.Send(
                 new OpenSlotWindowRequest(
                     FlightViewModel.DestinationIdentifier,
                     SlotId: null, // slotId is null for new slots
@@ -220,7 +216,7 @@ public partial class FlightLabelViewModel(
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -233,7 +229,7 @@ public partial class FlightLabelViewModel(
                 ? [FlightViewModel.AssignedRunwayIdentifier]
                 : Array.Empty<string>();
 
-            mediator.Send(
+            _mediator.Send(
                 new OpenSlotWindowRequest(
                     FlightViewModel.DestinationIdentifier,
                     SlotId: null, // slotId is null for new slots
@@ -243,7 +239,7 @@ public partial class FlightLabelViewModel(
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -252,7 +248,7 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(
+            _mediator.Send(
                 new OpenChangeFeederFixEstimateWindowRequest(
                     FlightViewModel.DestinationIdentifier,
                     FlightViewModel.Callsign,
@@ -261,7 +257,7 @@ public partial class FlightLabelViewModel(
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -275,13 +271,13 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(
+            _mediator.Send(
                 new RemoveRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign),
                 CancellationToken.None);
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -290,13 +286,13 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(
+            _mediator.Send(
                 new DesequenceRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign),
                 CancellationToken.None);
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -305,13 +301,13 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(
+            _mediator.Send(
                 new MakePendingRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign),
                 CancellationToken.None);
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -328,13 +324,13 @@ public partial class FlightLabelViewModel(
                 _ => throw new ArgumentException($"Invalid parameter type: {parameter?.GetType().Name ?? "null"}")
             };
 
-            mediator.Send(
+            _mediator.Send(
                 new ManualDelayRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign, maximumDelayMinutes),
                 CancellationToken.None);
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
@@ -343,16 +339,43 @@ public partial class FlightLabelViewModel(
     {
         try
         {
-            mediator.Send(new OpenCoordinationWindowRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign));
+            _mediator.Send(new OpenCoordinationWindowRequest(FlightViewModel.DestinationIdentifier, FlightViewModel.Callsign));
         }
         catch (Exception ex)
         {
-            errorReporter.ReportError(ex);
+            _errorReporter.ReportError(ex);
         }
     }
 
     [ObservableProperty]
     ObservableCollection<LabelItemViewModel> _labelItems = [];
+
+    readonly IMediator _mediator;
+    readonly IErrorReporter _errorReporter;
+    readonly MaestroViewModel _maestroViewModel;
+    readonly GlobalColourConfiguration _globalColorConfiguration;
+    readonly string[] _availableRunways;
+    readonly string[] _availableApproachTypes;
+
+    public FlightLabelViewModel(IMediator mediator,
+        IErrorReporter errorReporter,
+        MaestroViewModel maestroViewModel,
+        GlobalColourConfiguration globalColorConfiguration,
+        FlightDto flightViewModel,
+        string[] availableRunways,
+        string[] availableApproachTypes)
+    {
+        _mediator = mediator;
+        _errorReporter = errorReporter;
+        _maestroViewModel = maestroViewModel;
+        _globalColorConfiguration = globalColorConfiguration;
+        _availableRunways = availableRunways;
+        _availableApproachTypes = availableApproachTypes;
+        _flightViewModel = flightViewModel;
+
+        WeakReferenceMessenger.Default.Register<TrackSelectedMessage>(this, (_, m) =>
+            IsVatsysTrackSelected = m.Callsign == FlightViewModel.Callsign);
+    }
 
     public void UpdateLabelItems(LabelLayoutConfiguration labelLayout, FlightDto flight, int ladderIndex)
     {
@@ -448,13 +471,13 @@ public partial class FlightLabelViewModel(
         {
             var color = itemConfigColourSource switch
             {
-                LabelItemColourSource.Runway when maestroViewModel.AirportConfiguration.Colours is not null => GetColorByRunway(maestroViewModel.AirportConfiguration.Colours, flight),
-                LabelItemColourSource.ApproachType when maestroViewModel.AirportConfiguration.Colours is not null => GetColorByApproachType(maestroViewModel.AirportConfiguration.Colours, flight),
-                LabelItemColourSource.FeederFix when maestroViewModel.AirportConfiguration.Colours is not null => GetColorByFeederFix(maestroViewModel.AirportConfiguration.Colours, flight),
-                LabelItemColourSource.State => GetColorByState(globalColorConfiguration, flight),
-                LabelItemColourSource.RunwayMode => GetColorByRunwayMode(globalColorConfiguration, flight),
-                LabelItemColourSource.RequiredControlAction => GetColorByRequiredControlAction(itemConfig, globalColorConfiguration, flight),
-                LabelItemColourSource.RemainingControlAction => GetColorByRemainingControlAction(itemConfig, globalColorConfiguration, flight),
+                LabelItemColourSource.Runway when _maestroViewModel.AirportConfiguration.Colours is not null => GetColorByRunway(_maestroViewModel.AirportConfiguration.Colours, flight),
+                LabelItemColourSource.ApproachType when _maestroViewModel.AirportConfiguration.Colours is not null => GetColorByApproachType(_maestroViewModel.AirportConfiguration.Colours, flight),
+                LabelItemColourSource.FeederFix when _maestroViewModel.AirportConfiguration.Colours is not null => GetColorByFeederFix(_maestroViewModel.AirportConfiguration.Colours, flight),
+                LabelItemColourSource.State => GetColorByState(_globalColorConfiguration, flight),
+                LabelItemColourSource.RunwayMode => GetColorByRunwayMode(_globalColorConfiguration, flight),
+                LabelItemColourSource.RequiredControlAction => GetColorByRequiredControlAction(itemConfig, _globalColorConfiguration, flight),
+                LabelItemColourSource.RemainingControlAction => GetColorByRemainingControlAction(itemConfig, _globalColorConfiguration, flight),
                 _ => null
             };
 

--- a/source/Maestro.Wpf/Views/FlightLabelView.xaml
+++ b/source/Maestro.Wpf/Views/FlightLabelView.xaml
@@ -50,6 +50,10 @@
                                 <Setter Property="Visibility" Value="Visible"/>
                                 <Setter Property="BevelType" Value="Raised"/>
                             </DataTrigger>
+                            <DataTrigger Binding="{Binding IsVatsysTrackSelected}" Value="True">
+                                <Setter Property="Visibility" Value="Visible"/>
+                                <Setter Property="BevelType" Value="Raised"/>
+                            </DataTrigger>
                             <DataTrigger Binding="{Binding IsSelected}" Value="True">
                                 <Setter Property="Visibility" Value="Visible"/>
                                 <Setter Property="BevelType" Value="Outline"/>

--- a/source/Maestro.Wpf/Views/MaestroView.xaml.cs
+++ b/source/Maestro.Wpf/Views/MaestroView.xaml.cs
@@ -3,6 +3,8 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Messaging;
+using Maestro.Wpf.Contracts;
 using Maestro.Contracts.Flights;
 using Maestro.Contracts.Shared;
 using Maestro.Core.Configuration;
@@ -35,6 +37,7 @@ public partial class MaestroView
 
     // Flight label reuse pool
     private readonly Dictionary<string, FlightLabelView> _flightLabels = new();
+    private string? _vatsysSelectedTrackCallsign;
 
     DateTimeOffset ReferenceTime => DateTimeOffset.UtcNow.Add(ViewModel.ScrollOffset);
 
@@ -53,6 +56,9 @@ public partial class MaestroView
 
         Loaded += ControlLoaded;
         SizeChanged += OnSizeChanged;
+
+        WeakReferenceMessenger.Default.Register<VatsysTrackSelectedNotification>(this, (_, m) =>
+            _vatsysSelectedTrackCallsign = m.Callsign);
 
         // Subscribe to property changes that affect rendering
         maestroViewModel.PropertyChanged += (sender, args) =>
@@ -1217,7 +1223,8 @@ public partial class MaestroView
                         labelConfiguration.GlobalColours,
                         flight,
                         ViewModel.Runways,
-                        approachTypes);
+                        approachTypes,
+                        _vatsysSelectedTrackCallsign);
 
                     flightLabelViewModel.UpdateLabelItems(labelLayout, flight, ladderIndex);
 

--- a/source/Maestro.Wpf/Views/MaestroView.xaml.cs
+++ b/source/Maestro.Wpf/Views/MaestroView.xaml.cs
@@ -19,7 +19,7 @@ namespace Maestro.Wpf.Views;
 /// <summary>
 /// Interaction logic for MaestroView.xaml
 /// </summary>
-public partial class MaestroView
+public partial class MaestroView : IRecipient<VatsysTrackSelectedNotification>
 {
     const int FooterHeight = 32;
     const int LineThickness = 2;
@@ -57,8 +57,7 @@ public partial class MaestroView
         Loaded += ControlLoaded;
         SizeChanged += OnSizeChanged;
 
-        WeakReferenceMessenger.Default.Register<VatsysTrackSelectedNotification>(this, (_, m) =>
-            _vatsysSelectedTrackCallsign = m.Callsign);
+        WeakReferenceMessenger.Default.Register(this);
 
         // Subscribe to property changes that affect rendering
         maestroViewModel.PropertyChanged += (sender, args) =>
@@ -73,6 +72,11 @@ public partial class MaestroView
     }
 
     public MaestroViewModel ViewModel => (MaestroViewModel)DataContext;
+
+    public void Receive(VatsysTrackSelectedNotification message)
+    {
+        _vatsysSelectedTrackCallsign = message.Callsign;
+    }
 
     void TimerTick(object sender, EventArgs args)
     {


### PR DESCRIPTION
When a track or strip is designated in vatSys, a border will now appear around the flight label in the Maestro window to reflect the designation.

Closes https://github.com/YuKitsune/vMaestro/issues/17