### PR TITLE
fix: Stablise flights when changing approach type

### DIFF
--- a/source/Maestro.Core.Tests/Handlers/ChangeApproachTypeRequestHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/ChangeApproachTypeRequestHandlerTests.cs
@@ -56,6 +56,7 @@ public class ChangeApproachTypeRequestHandlerTests(ClockFixture clockFixture)
         var handler = new ChangeApproachTypeRequestHandler(
             sessionManager,
             new MockLocalConnectionManager(),
+            new AirportConfigurationProvider([airportConfiguration]),
             trajectoryService,
             clockFixture.Instance,
             mediator,
@@ -105,6 +106,7 @@ public class ChangeApproachTypeRequestHandlerTests(ClockFixture clockFixture)
         var handler = new ChangeApproachTypeRequestHandler(
             sessionManager,
             new MockLocalConnectionManager(),
+            new AirportConfigurationProvider([airportConfiguration]),
             trajectoryService,
             clockFixture.Instance,
             mediator,
@@ -158,6 +160,7 @@ public class ChangeApproachTypeRequestHandlerTests(ClockFixture clockFixture)
         var handler = new ChangeApproachTypeRequestHandler(
             sessionManager,
             new MockLocalConnectionManager(),
+            new AirportConfigurationProvider([airportConfiguration]),
             trajectoryService,
             clockFixture.Instance,
             mediator,
@@ -204,6 +207,7 @@ public class ChangeApproachTypeRequestHandlerTests(ClockFixture clockFixture)
         var handler = new ChangeApproachTypeRequestHandler(
             sessionManager,
             slaveConnectionManager,
+            new AirportConfigurationProvider([airportConfiguration]),
             trajectoryService,
             clockFixture.Instance,
             mediator,
@@ -220,6 +224,102 @@ public class ChangeApproachTypeRequestHandlerTests(ClockFixture clockFixture)
         slaveConnectionManager.Connection.InvokedRequests.Count.ShouldBe(1, "Request should be relayed to master");
         slaveConnectionManager.Connection.InvokedRequests[0].ShouldBe(request, "The relayed request should match the original request");
         flight.ApproachType.ShouldBe(originalApproachType, "Local flight should not be modified when relaying to master");
+    }
+
+    [Fact]
+    public async Task WhenChangingApproachType_AndTheFlightWasUnstable_ItBecomesStable()
+    {
+        var now = clockFixture.Instance.UtcNow();
+
+        // Arrange
+        var airportConfiguration = CreateAirportConfiguration();
+
+        var flight = new FlightBuilder("QFA1")
+            .WithFeederFix("BOREE")
+            .WithFeederFixEstimate(now.AddMinutes(10))
+            .WithApproachType(FirstApproachType)
+            .WithLandingEstimate(now.AddMinutes(30))
+            .WithLandingTime(now.AddMinutes(30))
+            .WithRunway("34R")
+            .WithState(State.Unstable)
+            .Build();
+
+        var trajectoryService = new MockTrajectoryService();
+
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration)
+            .WithSequence(s => s.WithTrajectoryService(trajectoryService).WithFlightsInOrder(flight))
+            .Build();
+
+        var mediator = Substitute.For<IMediator>();
+
+        var handler = new ChangeApproachTypeRequestHandler(
+            sessionManager,
+            new MockLocalConnectionManager(),
+            new AirportConfigurationProvider([airportConfiguration]),
+            trajectoryService,
+            clockFixture.Instance,
+            mediator,
+            Substitute.For<ILogger>());
+
+        var request = new ChangeApproachTypeRequest("YSSY", "QFA1", SecondApproachType);
+
+        flight.State.ShouldBe(State.Unstable, "Flight should initially be Unstable");
+
+        // Act
+        await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        flight.State.ShouldBe(State.Stable, "Unstable flight should become Stable when approach type is changed");
+    }
+
+    [Theory]
+    [InlineData(State.Stable)]
+    [InlineData(State.SuperStable)]
+    [InlineData(State.Frozen)]
+    [InlineData(State.Landed)]
+    public async Task WhenChangingApproachType_AndTheFlightWasNotUnstable_StateRemainsUnchanged(State state)
+    {
+        var now = clockFixture.Instance.UtcNow();
+
+        // Arrange
+        var airportConfiguration = CreateAirportConfiguration();
+
+        var flight = new FlightBuilder("QFA1")
+            .WithFeederFix("BOREE")
+            .WithFeederFixEstimate(now.AddMinutes(10))
+            .WithApproachType(FirstApproachType)
+            .WithLandingEstimate(now.AddMinutes(30))
+            .WithLandingTime(now.AddMinutes(30))
+            .WithRunway("34R")
+            .WithState(state)
+            .Build();
+
+        var trajectoryService = new MockTrajectoryService();
+
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration)
+            .WithSequence(s => s.WithTrajectoryService(trajectoryService).WithFlightsInOrder(flight))
+            .Build();
+
+        var mediator = Substitute.For<IMediator>();
+
+        var handler = new ChangeApproachTypeRequestHandler(
+            sessionManager,
+            new MockLocalConnectionManager(),
+            new AirportConfigurationProvider([airportConfiguration]),
+            trajectoryService,
+            clockFixture.Instance,
+            mediator,
+            Substitute.For<ILogger>());
+
+        var request = new ChangeApproachTypeRequest("YSSY", "QFA1", SecondApproachType);
+
+        flight.State.ShouldBe(state, $"Flight should initially be {state}");
+
+        // Act
+        await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        flight.State.ShouldBe(state, $"Flight state should remain {state} when changing approach type");
     }
 
     static AirportConfiguration CreateAirportConfiguration()

--- a/source/Maestro.Core/Handlers/ChangeApproachTypeRequestHandler.cs
+++ b/source/Maestro.Core/Handlers/ChangeApproachTypeRequestHandler.cs
@@ -1,5 +1,7 @@
 ﻿using Maestro.Contracts.Flights;
 using Maestro.Contracts.Sessions;
+using Maestro.Contracts.Shared;
+using Maestro.Core.Configuration;
 using Maestro.Core.Connectivity;
 using Maestro.Core.Extensions;
 using Maestro.Core.Infrastructure;
@@ -13,6 +15,7 @@ namespace Maestro.Core.Handlers;
 public class ChangeApproachTypeRequestHandler(
     ISessionManager sessionManager,
     IMaestroConnectionManager connectionManager,
+    IAirportConfigurationProvider airportConfigurationProvider,
     ITrajectoryService trajectoryService,
     IClock clock,
     IMediator mediator,
@@ -31,6 +34,8 @@ public class ChangeApproachTypeRequestHandler(
         }
 
         logger.Verbose("Changing approach type for {Callsign} to {NewApproachType} at {AirportIdentifier}", request.Callsign, request.ApproachType, request.AirportIdentifier);
+
+        var airportConfiguration = airportConfigurationProvider.GetAirportConfiguration(request.AirportIdentifier);
 
         var session = await sessionManager.GetSession(request.AirportIdentifier, cancellationToken);
         SessionDto sessionDto;
@@ -59,6 +64,10 @@ public class ChangeApproachTypeRequestHandler(
                 session.Sequence.UpperWind);
 
             flight.SetApproachType(request.ApproachType, trajectory);
+
+            // Unstable flights become Stable when approach type is changed manually
+            if (flight.State is State.Unstable)
+                flight.SetState(airportConfiguration.ManualInteractionState, clock);
 
             logger.Verbose(
                 "{Callsign} allocated to RWY {Runway} APCH {ApproachType} | TTG: {TimeToGo}, P: {Pressure}, PMax: {MaxPressure}",


### PR DESCRIPTION
Stablise flights when changing approach type to prevent it from changing during the scheduling algorithm.

Fixes https://github.com/YuKitsune/vMaestro/issues/77