### PR TITLE
feat(config)!: add airport-level DefaultOffModeSeparationSeconds

### DIFF
--- a/Maestro.yaml
+++ b/Maestro.yaml
@@ -105,6 +105,7 @@ Airports:
   MaxLandedFlights: 5
   LandedFlightTimeoutMinutes: 10
   LostFlightTimeoutMinutes: 10
+  DefaultOffModeSeparationSeconds: 300
 
   Colours:
     FeederFixes:
@@ -580,6 +581,7 @@ Airports:
   MaxLandedFlights: 5
   LandedFlightTimeoutMinutes: 10
   LostFlightTimeoutMinutes: 10
+  DefaultOffModeSeparationSeconds: 300
 
   RunwayModes:
   - Identifier: 09
@@ -1051,6 +1053,7 @@ Airports:
   MaxLandedFlights: 5
   LandedFlightTimeoutMinutes: 10
   LostFlightTimeoutMinutes: 10
+  DefaultOffModeSeparationSeconds: 300
 
   RunwayModes:
   - Identifier: 19
@@ -1863,36 +1866,32 @@ Airports:
   MaxLandedFlights: 5
   LandedFlightTimeoutMinutes: 10
   LostFlightTimeoutMinutes: 10
+  DefaultOffModeSeparationSeconds: 300
 
   RunwayModes:
   - Identifier: 21/24
     DependencyRateSeconds: 30
-    OffModeSeparationSeconds: 0
     Runways:
     - {Identifier: "21", ApproachType: A, LandingRateSeconds: 180}
     - {Identifier: "24", ApproachType: A, LandingRateSeconds: 180}
 
   - Identifier: "03"
     DependencyRateSeconds: 0
-    OffModeSeparationSeconds: 0
     Runways:
     - {Identifier: "03", ApproachType: A, LandingRateSeconds: 180}
 
   - Identifier: "06"
     DependencyRateSeconds: 0
-    OffModeSeparationSeconds: 0
     Runways:
     - {Identifier: "06", ApproachType: A, LandingRateSeconds: 180}
 
   - Identifier: "21"
     DependencyRateSeconds: 0
-    OffModeSeparationSeconds: 0
     Runways:
     - {Identifier: "21", ApproachType: A, LandingRateSeconds: 180}
 
   - Identifier: "24"
     DependencyRateSeconds: 0
-    OffModeSeparationSeconds: 0
     Runways:
     - {Identifier: "24", ApproachType: A, LandingRateSeconds: 180}
 

--- a/docs/docs/admin-guide/02-plugin-configuration.md
+++ b/docs/docs/admin-guide/02-plugin-configuration.md
@@ -271,6 +271,7 @@ Airports:
 | `AverageLandingSpeed` | integer | 150 | Average landing speed (TAS) in knots for distance calculations |
 | `UpperWindAltitude` | integer | 6000 | Altitude in feet for upper winds from GRIB data |
 | `DefaultMaxEnrouteLinearDelayMinutes` | integer | `8` | Default enroute delay capacity used when no matching enroute trajectory is configured |
+| `DefaultOffModeSeparationSeconds` | integer | - | Required. Default separation applied to flights landing on a runway not defined in the active runway mode. Used when an individual runway mode does not specify its own `OffModeSeparationSeconds`. |
 
 Flight states: `Unstable`, `Stable`, `SuperStable`, `Frozen`
 
@@ -301,7 +302,7 @@ All airport colours are optional. Values are RGB (0-255).
 RunwayModes:
   - Identifier: 34IVA
     DependencyRateSeconds: 0
-    OffModeSeparationSeconds: 0
+    OffModeSeparationSeconds: 300
     Runways:
       - Identifier: 34L
         ApproachType: I
@@ -318,7 +319,7 @@ RunwayModes:
 |----------|------|---------|-------------|
 | `Identifier` | string | - | Mode name |
 | `DependencyRateSeconds` | integer | 0 | Additional separation for dependent runways |
-| `OffModeSeparationSeconds` | integer | 0 | Separation for off-mode runways |
+| `OffModeSeparationSeconds` | integer | airport `DefaultOffModeSeparationSeconds` | Separation for off-mode runways. When omitted, the airport-level default is used. |
 | `Runways` | array | - | Runway configurations |
 
 #### Runway Configuration

--- a/docs/docs/admin-guide/migration-guides/v0.31-to-v0.32.md
+++ b/docs/docs/admin-guide/migration-guides/v0.31-to-v0.32.md
@@ -1,0 +1,68 @@
+# v0.31 to v0.32
+
+## Overview
+
+v0.32 introduces an airport-level default for off-mode runway separation.
+The per-mode `OffModeSeparationSeconds` property is now optional and falls back to the airport-level default when omitted.
+
+There are three breaking changes that require updates to your `Maestro.yaml`.
+
+## Before You Start
+
+Back up your existing `Maestro.yaml` before making any changes.
+
+## Breaking Changes
+
+### `DefaultOffModeSeparationSeconds` is now required on each airport
+
+A new required property `DefaultOffModeSeparationSeconds` must be set on every airport.
+It defines the default minimum separation, in seconds, applied to flights landing on a runway not defined in the active runway mode.
+Individual runway modes that do not specify `OffModeSeparationSeconds` will use this value.
+
+In previous versions, the per-mode `OffModeSeparationSeconds` defaulted to `0`, which silently disabled off-mode separation when the value was not explicitly set.
+This default has been removed to force an explicit, safe value at the airport level.
+
+Before:
+
+```yaml
+Airports:
+  - Identifier: YSSY
+    FeederFixes: [RIVET, WELSH, BOREE, YAKKA, MARLN]
+    Runways: [34L, 34R, 16L, 16R]
+
+    RunwayModes:
+      - Identifier: 34I
+        DependencyRateSeconds: 60
+        Runways:
+          - {Identifier: 34L, LandingRateSeconds: 180}
+          - {Identifier: 34R, LandingRateSeconds: 180}
+```
+
+After:
+
+```yaml
+Airports:
+  - Identifier: YSSY
+    FeederFixes: [RIVET, WELSH, BOREE, YAKKA, MARLN]
+    Runways: [34L, 34R, 16L, 16R]
+    DefaultOffModeSeparationSeconds: 300
+
+    RunwayModes:
+      - Identifier: 34I
+        DependencyRateSeconds: 60
+        Runways:
+          - {Identifier: 34L, LandingRateSeconds: 180}
+          - {Identifier: 34R, LandingRateSeconds: 180}
+```
+
+**Steps:**
+
+1. Add `DefaultOffModeSeparationSeconds` to every airport entry in `Maestro.yaml`. A value of `300` (5 minutes) is a reasonable starting point; choose a value appropriate for the airport.
+2. Review each runway mode under that airport. If `OffModeSeparationSeconds` is set, decide whether it should remain as an explicit per-mode override, or be removed so the airport-level default applies.
+3. Remove any per-mode `OffModeSeparationSeconds: 0` entries unless a zero value is genuinely intended. Previously these were often set to `0` to match the implicit default; with the new airport-level default they would suppress that default.
+
+## Behaviour Notes
+
+- `DependencyRateSeconds` is unchanged. It remains optional with a default of `0`.
+- The per-mode `OffModeSeparationSeconds` is now optional. When omitted, the airport-level `DefaultOffModeSeparationSeconds` is used at the point a runway mode is constructed.
+- An explicit per-mode value (including `0`) is preserved as-is and overrides the airport-level default.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -19,6 +19,7 @@ const sidebars = {
       label: 'Migration Guides',
       link: null,
       items: [
+        'admin-guide/migration-guides/v0.31-to-v0.32',
         'admin-guide/migration-guides/v0.30-to-v0.31',
       ],
     },

--- a/source/Maestro.Core.Tests/Builders/AirportConfigurationBuilder.cs
+++ b/source/Maestro.Core.Tests/Builders/AirportConfigurationBuilder.cs
@@ -10,6 +10,7 @@ public class AirportConfigurationBuilder(string identifier)
 
     string[] _runways = [];
     string[] _feederFixes = [];
+    int _defaultOffModeSeparationSeconds = 0;
     List<RunwayModeConfiguration> _runwayModes = [];
     List<TerminalTrajectoryConfiguration> _trajectories = [];
     List<DepartureConfiguration> _departures = [];
@@ -23,6 +24,12 @@ public class AirportConfigurationBuilder(string identifier)
     public AirportConfigurationBuilder WithFeederFixes(params string[] feederFixes)
     {
         _feederFixes = feederFixes;
+        return this;
+    }
+
+    public AirportConfigurationBuilder WithDefaultOffModeSeparationSeconds(int seconds)
+    {
+        _defaultOffModeSeparationSeconds = seconds;
         return this;
     }
 
@@ -158,6 +165,7 @@ public class AirportConfigurationBuilder(string identifier)
             Identifier = identifier,
             Runways = _runways,
             FeederFixes = _feederFixes,
+            DefaultOffModeSeparationSeconds = _defaultOffModeSeparationSeconds,
             RunwayModes = _runwayModes.ToArray(),
             TerminalTrajectories = _trajectories.ToArray(),
             DepartureAirports = _departures.ToArray(),

--- a/source/Maestro.Core.Tests/Builders/SequenceBuilder.cs
+++ b/source/Maestro.Core.Tests/Builders/SequenceBuilder.cs
@@ -35,7 +35,9 @@ public class SequenceBuilder(AirportConfiguration airportConfiguration)
 
     public SequenceBuilder WithRunwayMode(RunwayModeConfiguration runwayModeConfiguration)
     {
-        _runwayMode = new RunwayMode(runwayModeConfiguration);
+        _runwayMode = new RunwayMode(
+            runwayModeConfiguration,
+            TimeSpan.FromSeconds(airportConfiguration.DefaultOffModeSeparationSeconds));
         return this;
     }
 
@@ -61,7 +63,8 @@ public class SequenceBuilder(AirportConfiguration airportConfiguration)
                             FeederFixes = []
                         }
                     ]
-                }));
+                },
+                TimeSpan.FromSeconds(airportConfiguration.DefaultOffModeSeparationSeconds)));
     }
 
     public SequenceBuilder WithFlight(Flight flight)
@@ -79,7 +82,9 @@ public class SequenceBuilder(AirportConfiguration airportConfiguration)
     public Sequence Build()
     {
         var sequence = new Sequence(airportConfiguration, _trajectoryService, _clock, _logger);
-        sequence.ChangeRunwayMode(_runwayMode ?? new RunwayMode(airportConfiguration.RunwayModes.First()));
+        sequence.ChangeRunwayMode(_runwayMode ?? new RunwayMode(
+            airportConfiguration.RunwayModes.First(),
+            TimeSpan.FromSeconds(airportConfiguration.DefaultOffModeSeparationSeconds)));
         for (var i = 0; i < _flights.Count; i++)
         {
             sequence.Insert(i, _flights[i]);

--- a/source/Maestro.Core.Tests/Handlers/InsertFlightRequestHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/InsertFlightRequestHandlerTests.cs
@@ -700,7 +700,9 @@ public class InsertFlightRequestHandlerTests(
 
         // Schedule a runway change from T10 to T15
         session.Sequence.ChangeRunwayMode(
-            new RunwayMode(airportConfiguration.RunwayModes[1]),
+            new RunwayMode(
+                airportConfiguration.RunwayModes[1],
+                TimeSpan.FromSeconds(airportConfiguration.DefaultOffModeSeparationSeconds)),
             now.AddMinutes(10),
             now.AddMinutes(15));
 

--- a/source/Maestro.Core.Tests/Handlers/ManualDelayRequestHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/ManualDelayRequestHandlerTests.cs
@@ -482,7 +482,7 @@ public class ManualDelayRequestHandlerTests(ClockFixture clockFixture)
                     FeederFixes = []
                 }
             ]
-        });
+        }, TimeSpan.FromSeconds(airportConfiguration.DefaultOffModeSeparationSeconds));
         sequence.ChangeRunwayMode(newRunwayMode, lastLandingTimeForOldMode, firstLandingTimeForNewMode);
 
         var handler = GetHandler(sessionManager, sequence);

--- a/source/Maestro.Core.Tests/Handlers/RecomputeRequestHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/RecomputeRequestHandlerTests.cs
@@ -47,7 +47,8 @@ public class RecomputeRequestHandlerTests(ClockFixture clockFixture)
                 new RunwayConfiguration { Identifier = "34L", ApproachType = string.Empty, LandingRateSeconds = 180, FeederFixes = ["RIVET", "WELSH"]},
                 new RunwayConfiguration { Identifier = "34R", ApproachType = string.Empty, LandingRateSeconds = 180, FeederFixes = ["RIVET", "WELSH"] }
             ]
-        });
+        },
+        TimeSpan.Zero);
 
     [Fact]
     public async Task TheFlightIsMovedBasedOnItsLandingEstimate()

--- a/source/Maestro.Core.Tests/Handlers/TrySwapRunwayModesRequestHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/TrySwapRunwayModesRequestHandlerTests.cs
@@ -18,31 +18,35 @@ public class TrySwapRunwayModesRequestHandlerTests(ClockFixture clockFixture)
 {
     readonly DateTimeOffset _now = clockFixture.Instance.UtcNow();
 
-    readonly RunwayMode _firstRunwayMode = new(new RunwayModeConfiguration
-    {
-        Identifier = "FIRST",
-        Runways =
-        [
-            new RunwayConfiguration
-            {
-                Identifier = "34L",
-                LandingRateSeconds = 180
-            }
-        ]
-    });
+    readonly RunwayMode _firstRunwayMode = new(
+        new RunwayModeConfiguration
+        {
+            Identifier = "FIRST",
+            Runways =
+            [
+                new RunwayConfiguration
+                {
+                    Identifier = "34L",
+                    LandingRateSeconds = 180
+                }
+            ]
+        },
+        TimeSpan.Zero);
 
-    readonly RunwayMode _secondRunwayMode = new(new RunwayModeConfiguration
-    {
-        Identifier = "SECOND",
-        Runways =
-        [
-            new RunwayConfiguration
-            {
-                Identifier = "16R",
-                LandingRateSeconds = 180
-            }
-        ]
-    });
+    readonly RunwayMode _secondRunwayMode = new(
+        new RunwayModeConfiguration
+        {
+            Identifier = "SECOND",
+            Runways =
+            [
+                new RunwayConfiguration
+                {
+                    Identifier = "16R",
+                    LandingRateSeconds = 180
+                }
+            ]
+        },
+        TimeSpan.Zero);
 
     [Fact]
     public async Task WhenNoChangeIsInProgress_NothingHappens()

--- a/source/Maestro.Core/Configuration/AirportConfiguration.cs
+++ b/source/Maestro.Core/Configuration/AirportConfiguration.cs
@@ -87,6 +87,13 @@ public class AirportConfiguration
     /// </summary>
     public int LostFlightTimeoutMinutes { get; init; } = 10;
 
+    /// <summary>
+    ///     The default minimum amount of separation, in seconds, to apply to flights landing on a runway not defined
+    ///     in the active runway mode. Used when an individual <see cref="RunwayModeConfiguration"/> does not specify
+    ///     its own <c>OffModeSeparationSeconds</c>.
+    /// </summary>
+    public required int DefaultOffModeSeparationSeconds { get; init; }
+
     public required RunwayModeConfiguration[] RunwayModes { get; init; }
 
     // Look-up tables

--- a/source/Maestro.Core/Configuration/RunwayModeConfiguration.cs
+++ b/source/Maestro.Core/Configuration/RunwayModeConfiguration.cs
@@ -14,8 +14,9 @@ public class RunwayModeConfiguration
 
     /// <summary>
     ///     The minimum amount of separation to apply to flights landing on a runway not defined in this runway mode.
+    ///     When <c>null</c>, the airport-level <see cref="AirportConfiguration.DefaultOffModeSeparationSeconds"/> is used.
     /// </summary>
-    public int OffModeSeparationSeconds { get; init; } = 0;
+    public int? OffModeSeparationSeconds { get; init; }
 
     public required RunwayConfiguration[] Runways { get; init; }
 }

--- a/source/Maestro.Core/Handlers/ChangeRunwayModeRequestHandler.cs
+++ b/source/Maestro.Core/Handlers/ChangeRunwayModeRequestHandler.cs
@@ -50,7 +50,9 @@ public class ChangeRunwayModeRequestHandler(
                 return;
             }
 
-            var configuration = new RunwayMode(runwayModeConfig);
+            var configuration = new RunwayMode(
+                runwayModeConfig,
+                TimeSpan.FromSeconds(airportConfiguration.DefaultOffModeSeparationSeconds));
             foreach (var runwayDto in request.RunwayMode.Runways)
             {
                 var runwayIdentifier = runwayDto.Identifier;

--- a/source/Maestro.Core/Model/RunwayMode.cs
+++ b/source/Maestro.Core/Model/RunwayMode.cs
@@ -9,14 +9,16 @@ namespace Maestro.Core.Model;
 
 public class RunwayMode
 {
-    public RunwayMode(RunwayModeConfiguration runwayModeConfigurationConfiguration)
+    public RunwayMode(RunwayModeConfiguration runwayModeConfigurationConfiguration, TimeSpan defaultOffModeSeparation)
     {
         Identifier = runwayModeConfigurationConfiguration.Identifier;
         Runways = runwayModeConfigurationConfiguration.Runways
             .Select(r => new Runway(r))
             .ToArray();
         DependencyRate = TimeSpan.FromSeconds(runwayModeConfigurationConfiguration.DependencyRateSeconds);
-        OffModeSeparation = TimeSpan.FromSeconds(runwayModeConfigurationConfiguration.OffModeSeparationSeconds);
+        OffModeSeparation = runwayModeConfigurationConfiguration.OffModeSeparationSeconds.HasValue
+            ? TimeSpan.FromSeconds(runwayModeConfigurationConfiguration.OffModeSeparationSeconds.Value)
+            : defaultOffModeSeparation;
     }
 
     public RunwayMode(RunwayModeDto runwayModeDto)

--- a/source/Maestro.Core/Model/Sequence.cs
+++ b/source/Maestro.Core/Model/Sequence.cs
@@ -47,7 +47,9 @@ public class Sequence
             .ForContext("AirportIdentifier", airportConfiguration.Identifier);
 
         AirportIdentifier = airportConfiguration.Identifier;
-        CurrentRunwayMode = new RunwayMode(airportConfiguration.RunwayModes.First());
+        CurrentRunwayMode = new RunwayMode(
+            airportConfiguration.RunwayModes.First(),
+            TimeSpan.FromSeconds(airportConfiguration.DefaultOffModeSeparationSeconds));
 
         UpperWindAltitude = airportConfiguration.UpperWindAltitude;
     }

--- a/source/Maestro.Plugin/Handlers/MaestroSessionCreatedNotificationHandler.cs
+++ b/source/Maestro.Plugin/Handlers/MaestroSessionCreatedNotificationHandler.cs
@@ -25,7 +25,7 @@ public class MaestroSessionCreatedNotificationHandler(
         var airportConfiguration = airportConfigurationProvider.GetAirportConfiguration(notification.AirportIdentifier);
 
         var runwayModes = airportConfiguration.RunwayModes
-            .Select(rm => new RunwayModeViewModel(rm))
+            .Select(rm => new RunwayModeViewModel(rm, airportConfiguration.DefaultOffModeSeparationSeconds))
             .ToArray();
 
         windowManager.FocusOrCreateWindow(

--- a/source/Maestro.Plugin/Handlers/OpenTerminalConfigurationWindowRequestHandler.cs
+++ b/source/Maestro.Plugin/Handlers/OpenTerminalConfigurationWindowRequestHandler.cs
@@ -34,7 +34,7 @@ public class OpenTerminalConfigurationWindowRequestHandler(
         }
 
         var runwayModes = airportConfiguration.RunwayModes
-            .Select(r => new RunwayModeViewModel(r))
+            .Select(r => new RunwayModeViewModel(r, airportConfiguration.DefaultOffModeSeparationSeconds))
             .ToArray();
 
         windowManager.FocusOrCreateWindow(

--- a/source/Maestro.Wpf/ViewModels/AirportViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/AirportViewModel.cs
@@ -9,12 +9,12 @@ public partial class RunwayModeViewModel : ObservableObject
     [ObservableProperty]
     RunwayViewModel[] _runways = [];
 
-    public RunwayModeViewModel(RunwayModeConfiguration runwayModeConfiguration)
+    public RunwayModeViewModel(RunwayModeConfiguration runwayModeConfiguration, int defaultOffModeSeparationSeconds)
         : this(
             runwayModeConfiguration.Identifier,
             runwayModeConfiguration.Runways.Select(r => new RunwayViewModel(r.Identifier, r.ApproachType, r.LandingRateSeconds, r.FeederFixes)).ToArray(),
             runwayModeConfiguration.DependencyRateSeconds,
-            runwayModeConfiguration.OffModeSeparationSeconds)
+            runwayModeConfiguration.OffModeSeparationSeconds ?? defaultOffModeSeparationSeconds)
     {
     }
 


### PR DESCRIPTION
Makes per-mode `OffModeSeparationSeconds` optional and falls back to a new required airport-level `DefaultOffModeSeparationSeconds`, removing the unsafe implicit `0` default.

Fixes https://github.com/YuKitsune/vMaestro/issues/109