### PR TITLE
fix(sequencing): insert new flights at end of sequence when no later estimate found

### DIFF
--- a/source/Maestro.Core/Handlers/FlightUpdatedHandler.cs
+++ b/source/Maestro.Core/Handlers/FlightUpdatedHandler.cs
@@ -164,7 +164,7 @@ public class FlightUpdatedHandler(
                         f => f.LandingEstimate.IsAfter(approximateLandingEstimate.Value));
 
                     if (insertionIndex == -1)
-                        insertionIndex = Math.Min(earliestInsertionIndex, session.Sequence.Flights.Count);
+                        insertionIndex = session.Sequence.Flights.Count;
 
                     sequencedFlight = new Flight(
                         callsign: notification.Callsign,


### PR DESCRIPTION
Fixes #147.

When inserting a new flight and no existing flight had a later `LandingEstimate`, the fallback `Math.Min(earliestInsertionIndex, Flights.Count)` always resolved to `earliestInsertionIndex`. This placed the new flight at the *front* of the Unstable/Stable region rather than the end, corrupting sequence order.

The corrupted order caused the scheduler to constrain previously-Stable flights to land *after* the newly inserted flight, applying cascading delays of 40–70 minutes. This pushed those flights' STAs beyond the visible ladder window, causing their labels to disappear until the sequence self-corrected.

The fix matches the existing behaviour in the Unstable repositioning path, which already uses `Flights.Count` as its fallback.