### PR TITLE
fix(plugin): fix false landing detections for uncoupled flights

### DIFF
--- a/source/Maestro.Plugin.Tests/AircraftLandingCircuitBreakerTests.cs
+++ b/source/Maestro.Plugin.Tests/AircraftLandingCircuitBreakerTests.cs
@@ -80,6 +80,31 @@ public class AircraftLandingCircuitBreakerTests
     }
 
     [Fact]
+    public void ResetBreaker_AfterBreakerSet_ShouldAllowBreakerToBeSetAgain()
+    {
+        var circuitBoard = new AircraftLandingCircuitBreaker();
+
+        circuitBoard.TrySetBreaker("QFA123");
+        circuitBoard.ResetBreaker("QFA123");
+        var result = circuitBoard.TrySetBreaker("QFA123");
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ResetBreaker_DoesNotAffectOtherCallsigns()
+    {
+        var circuitBoard = new AircraftLandingCircuitBreaker();
+
+        circuitBoard.TrySetBreaker("QFA123");
+        circuitBoard.TrySetBreaker("VOZ456");
+        circuitBoard.ResetBreaker("QFA123");
+
+        circuitBoard.TrySetBreaker("QFA123").ShouldBeTrue();
+        circuitBoard.TrySetBreaker("VOZ456").ShouldBeFalse();
+    }
+
+    [Fact]
     public void TrySetBreaker_MultipleConcurrentCallsigns_ShouldMaintainIndependence()
     {
         var circuitBoard = new AircraftLandingCircuitBreaker();

--- a/source/Maestro.Plugin/AircraftLandingCircuitBreaker.cs
+++ b/source/Maestro.Plugin/AircraftLandingCircuitBreaker.cs
@@ -22,6 +22,17 @@ public class AircraftLandingCircuitBreaker
         }
     }
 
+    /// <summary>
+    /// Resets the breaker for the given callsign, allowing it to be tripped again.
+    /// </summary>
+    public void ResetBreaker(string callsign)
+    {
+        lock (_gate)
+        {
+            _breakers.Remove(callsign);
+        }
+    }
+
     class CircuitBreaker
     {
         public bool IsSet { get; private set; }

--- a/source/Maestro.Plugin/Plugin.cs
+++ b/source/Maestro.Plugin/Plugin.cs
@@ -374,7 +374,7 @@ public class Plugin : IPlugin
         var lastWaypointIndex = updated.ParsedRoute.FindLastIndex(s => s.Type == FDP2.FDR.ExtractedRoute.Segment.SegmentTypes.WAYPOINT);
         var didPassLastWaypoint = updated.ParsedRoute.OverflownIndex >= lastWaypointIndex;
 
-        var isOnGround = updated.CoupledTrack is null || updated.CoupledTrack.OnGround;
+        var isOnGround = updated.CoupledTrack is not null && updated.CoupledTrack.OnGround;
 
         return didPassLastWaypoint && isOnGround;
     }


### PR DESCRIPTION
Fixes landing detection triggering for uncoupled flights.

Landing detection now requires:
- Last waypoint overflown
- Coupled to a radar track
- On the ground

Relates to #153.