### PR TITLE
fix: Sort landing times before computing intervals

### DIFF
--- a/source/Maestro.Core.Tests/Sessions/LandingStatisticsTests.cs
+++ b/source/Maestro.Core.Tests/Sessions/LandingStatisticsTests.cs
@@ -157,6 +157,25 @@ public class LandingStatisticsTests(ClockFixture clockFixture)
     }
 
     [Fact]
+    public void RecordLandingTime_OutOfOrderLandingTimes_ComputesCorrectAverageInterval()
+    {
+        // Arrange
+        var statistics = new LandingStatistics(_logger);
+        var runway = CreateRunway("34L", _acceptanceRate);
+
+        // Act - Record landings out of chronological order
+        statistics.RecordLandingTime(runway, _now.AddMinutes(-8), clockFixture.Instance);
+        statistics.RecordLandingTime(runway, _now.AddMinutes(-6), clockFixture.Instance);
+        statistics.RecordLandingTime(runway, _now.AddMinutes(-10), clockFixture.Instance);
+
+        // Assert - average interval should be 6 minutes, not negative
+        statistics.AchievedLandingRates["34L"].ShouldBeOfType<AchievedRate>();
+        var achievedRate = (AchievedRate)statistics.AchievedLandingRates["34L"];
+        achievedRate.AverageLandingInterval.ShouldBe(TimeSpan.FromMinutes(2));
+        achievedRate.LandingIntervalDeviation.ShouldBe(TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
     public void Snapshot_CreatesCorrectDto()
     {
         // Arrange
@@ -284,23 +303,6 @@ public class LandingStatisticsTests(ClockFixture clockFixture)
         // Assert
         statistics.AchievedLandingRates.ShouldNotContainKey("34L");
         statistics.AchievedLandingRates.ShouldContainKey("34R");
-    }
-
-    [Fact]
-    public void RecordLandingTime_OutOfOrderLandingTimes_ComputesCorrectAverageInterval()
-    {
-        // Arrange
-        var statistics = new LandingStatistics(_logger);
-        var runway = CreateRunway("34L", _acceptanceRate);
-
-        // Act - Record landings out of chronological order
-        statistics.RecordLandingTime(runway, _now.AddMinutes(-4), clockFixture.Instance);
-        statistics.RecordLandingTime(runway, _now.AddMinutes(-10), clockFixture.Instance); // earlier than previous
-
-        // Assert - average interval should be 6 minutes, not negative
-        statistics.AchievedLandingRates["34L"].ShouldBeOfType<AchievedRate>();
-        var achievedRate = (AchievedRate)statistics.AchievedLandingRates["34L"];
-        achievedRate.AverageLandingInterval.ShouldBe(TimeSpan.FromMinutes(6));
     }
 
     static Runway CreateRunway(string identifier, TimeSpan acceptanceRate)

--- a/source/Maestro.Core.Tests/Sessions/LandingStatisticsTests.cs
+++ b/source/Maestro.Core.Tests/Sessions/LandingStatisticsTests.cs
@@ -286,6 +286,23 @@ public class LandingStatisticsTests(ClockFixture clockFixture)
         statistics.AchievedLandingRates.ShouldContainKey("34R");
     }
 
+    [Fact]
+    public void RecordLandingTime_OutOfOrderLandingTimes_ComputesCorrectAverageInterval()
+    {
+        // Arrange
+        var statistics = new LandingStatistics(_logger);
+        var runway = CreateRunway("34L", _acceptanceRate);
+
+        // Act - Record landings out of chronological order
+        statistics.RecordLandingTime(runway, _now.AddMinutes(-4), clockFixture.Instance);
+        statistics.RecordLandingTime(runway, _now.AddMinutes(-10), clockFixture.Instance); // earlier than previous
+
+        // Assert - average interval should be 6 minutes, not negative
+        statistics.AchievedLandingRates["34L"].ShouldBeOfType<AchievedRate>();
+        var achievedRate = (AchievedRate)statistics.AchievedLandingRates["34L"];
+        achievedRate.AverageLandingInterval.ShouldBe(TimeSpan.FromMinutes(6));
+    }
+
     static Runway CreateRunway(string identifier, TimeSpan acceptanceRate)
     {
         return new Runway(identifier, "", acceptanceRate, []);

--- a/source/Maestro.Core/Sessions/LandingStatistics.cs
+++ b/source/Maestro.Core/Sessions/LandingStatistics.cs
@@ -52,11 +52,12 @@ public class LandingStatistics(ILogger logger)
         if (actualLandingTimes.Count == 0)
             return new NoDeviation();
 
+        var sortedTimes = actualLandingTimes.OrderBy(t => t).ToList();
         var diffs = new List<TimeSpan>();
-        for (var i = 1; i < actualLandingTimes.Count; i++)
+        for (var i = 1; i < sortedTimes.Count; i++)
         {
-            var previous = actualLandingTimes[i - 1];
-            var current = actualLandingTimes[i];
+            var previous = sortedTimes[i - 1];
+            var current = sortedTimes[i];
             diffs.Add(current - previous);
         }
 


### PR DESCRIPTION
Sorts landing times chronologically before computing intervals in `CalculateAchievedRate`. This prevents out-of-order timestamps from producing negative diffs, which caused the bogus achieved rate and deviation values reported in #94.

Also adds a test covering the out-of-order case.