### PR TITLE
fix: refresh popup windows when session updates

### DIFF
--- a/source/Maestro.Plugin/Handlers/OpenDesequencedWindowRequestHandler.cs
+++ b/source/Maestro.Plugin/Handlers/OpenDesequencedWindowRequestHandler.cs
@@ -1,4 +1,7 @@
-﻿using Maestro.Plugin.Infrastructure;
+﻿using Maestro.Contracts.Sessions;
+using Maestro.Core.Extensions;
+using Maestro.Core.Sessions;
+using Maestro.Plugin.Infrastructure;
 using Maestro.Wpf.Contracts;
 using Maestro.Wpf.Integrations;
 using Maestro.Wpf.ViewModels;
@@ -7,11 +10,23 @@ using MediatR;
 
 namespace Maestro.Plugin.Handlers;
 
-public class OpenDesequencedWindowRequestHandler(WindowManager windowManager, IMediator mediator, IErrorReporter errorReporter)
+public class OpenDesequencedWindowRequestHandler(
+    WindowManager windowManager,
+    ISessionManager sessionManager,
+    IMediator mediator,
+    IErrorReporter errorReporter)
     : IRequestHandler<OpenDesequencedWindowRequest, OpenDesequencedWindowResponse>
 {
-    public Task<OpenDesequencedWindowResponse> Handle(OpenDesequencedWindowRequest request, CancellationToken cancellationToken)
+    public async Task<OpenDesequencedWindowResponse> Handle(OpenDesequencedWindowRequest request, CancellationToken cancellationToken)
     {
+        var session = await sessionManager.GetSession(request.AirportIdentifier, cancellationToken);
+
+        SessionDto sessionDto;
+        using (await session.Semaphore.LockAsync(cancellationToken))
+        {
+            sessionDto = session.Snapshot();
+        }
+
         windowManager.FocusOrCreateWindow(
             WindowKeys.Desequenced(request.AirportIdentifier),
             "De-sequenced",
@@ -21,8 +36,8 @@ public class OpenDesequencedWindowRequestHandler(WindowManager windowManager, IM
                     windowHandle,
                     errorReporter,
                     request.AirportIdentifier,
-                    request.Callsigns)));
+                    sessionDto)));
 
-        return Task.FromResult(new OpenDesequencedWindowResponse());
+        return new OpenDesequencedWindowResponse();
     }
 }

--- a/source/Maestro.Plugin/Handlers/OpenInsertFlightWindowRequestHandler.cs
+++ b/source/Maestro.Plugin/Handlers/OpenInsertFlightWindowRequestHandler.cs
@@ -1,4 +1,7 @@
-﻿using Maestro.Plugin.Infrastructure;
+﻿using Maestro.Contracts.Sessions;
+using Maestro.Core.Extensions;
+using Maestro.Core.Sessions;
+using Maestro.Plugin.Infrastructure;
 using Maestro.Wpf.Contracts;
 using Maestro.Wpf.Integrations;
 using Maestro.Wpf.ViewModels;
@@ -7,11 +10,23 @@ using MediatR;
 
 namespace Maestro.Plugin.Handlers;
 
-public class OpenInsertFlightWindowRequestHandler(WindowManager windowManager, IMediator mediator, IErrorReporter errorReporter)
+public class OpenInsertFlightWindowRequestHandler(
+    WindowManager windowManager,
+    ISessionManager sessionManager,
+    IMediator mediator,
+    IErrorReporter errorReporter)
     : IRequestHandler<OpenInsertFlightWindowRequest>
 {
-    public Task Handle(OpenInsertFlightWindowRequest request, CancellationToken cancellationToken)
+    public async Task Handle(OpenInsertFlightWindowRequest request, CancellationToken cancellationToken)
     {
+        var session = await sessionManager.GetSession(request.AirportIdentifier, cancellationToken);
+
+        SessionDto sessionDto;
+        using (await session.Semaphore.LockAsync(cancellationToken))
+        {
+            sessionDto = session.Snapshot();
+        }
+
         windowManager.FocusOrCreateWindow(
             WindowKeys.InsertFlight(request.AirportIdentifier),
             "Insert a Flight",
@@ -20,15 +35,12 @@ public class OpenInsertFlightWindowRequestHandler(WindowManager windowManager, I
                 var viewModel = new InsertFlightViewModel(
                     request.AirportIdentifier,
                     request.Options,
-                    request.LandedFlights,
-                    request.FlightDataRecords,
+                    sessionDto,
                     windowHandle,
                     mediator,
                     errorReporter);
 
                 return new InsertFlightView(viewModel);
             });
-
-        return Task.CompletedTask;
     }
 }

--- a/source/Maestro.Plugin/Handlers/OpenPendingDeparturesWindowRequestHandler.cs
+++ b/source/Maestro.Plugin/Handlers/OpenPendingDeparturesWindowRequestHandler.cs
@@ -32,14 +32,8 @@ public class OpenPendingDeparturesWindowRequestHandler(
             sessionDto = session.Snapshot();
         }
 
-        var activatedCallsigns = new HashSet<string>(
-            sessionDto.Sequence.Flights.Select(f => f.Callsign)
-                .Concat(sessionDto.DeSequencedFlights.Select(f => f.Callsign)),
-            StringComparer.OrdinalIgnoreCase);
-
-        var departureFlights = sessionDto.FlightDataRecords
-            .Where(r => !activatedCallsigns.Contains(r.Callsign) &&
-                        airportConfiguration.DepartureAirports.Any(d => d.Identifier == r.Origin))
+        var departureAirportIdentifiers = airportConfiguration.DepartureAirports
+            .Select(d => d.Identifier)
             .ToArray();
 
         windowManager.FocusOrCreateWindow(
@@ -49,7 +43,8 @@ public class OpenPendingDeparturesWindowRequestHandler(
             {
                 var viewModel = new PendingDeparturesViewModel(
                     request.AirportIdentifier,
-                    departureFlights,
+                    departureAirportIdentifiers,
+                    sessionDto,
                     windowHandle,
                     mediator,
                     clock,

--- a/source/Maestro.Wpf/Contracts/OpenDesequencedWindowRequest.cs
+++ b/source/Maestro.Wpf/Contracts/OpenDesequencedWindowRequest.cs
@@ -3,4 +3,4 @@
 namespace Maestro.Wpf.Contracts;
 
 public record OpenDesequencedWindowResponse;
-public record OpenDesequencedWindowRequest(string AirportIdentifier, string[] Callsigns) : IRequest<OpenDesequencedWindowResponse>;
+public record OpenDesequencedWindowRequest(string AirportIdentifier) : IRequest<OpenDesequencedWindowResponse>;

--- a/source/Maestro.Wpf/Contracts/OpenInsertFlightWindowRequest.cs
+++ b/source/Maestro.Wpf/Contracts/OpenInsertFlightWindowRequest.cs
@@ -5,7 +5,5 @@ namespace Maestro.Wpf.Contracts;
 
 public record OpenInsertFlightWindowRequest(
     string AirportIdentifier,
-    IInsertFlightOptions Options,
-    FlightDto[] LandedFlights,
-    FlightDataRecord[] FlightDataRecords)
+    IInsertFlightOptions Options)
     : IRequest;

--- a/source/Maestro.Wpf/ViewModels/DesequencedViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/DesequencedViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Maestro.Contracts.Flights;
+using Maestro.Contracts.Sessions;
 using Maestro.Wpf.Integrations;
 using MediatR;
 
@@ -21,13 +23,27 @@ public partial class DesequencedViewModel : ObservableObject
         IWindowHandle windowHandle,
         IErrorReporter errorReporter,
         string airportIdentifier,
-        string[] callsigns)
+        SessionDto session)
     {
         AirportIdentifier = airportIdentifier;
         _errorReporter = errorReporter;
-        Callsigns = callsigns.ToList();
         _mediator = mediator;
         _windowHandle = windowHandle;
+
+        ApplySession(session);
+
+        WeakReferenceMessenger.Default.Register<SessionUpdatedNotification>(this, (_, notification) =>
+        {
+            if (notification.AirportIdentifier != AirportIdentifier)
+                return;
+
+            ApplySession(notification.Session);
+        });
+    }
+
+    void ApplySession(SessionDto session)
+    {
+        Callsigns = session.DeSequencedFlights.Select(f => f.Callsign).ToList();
     }
 
     public string AirportIdentifier { get; }

--- a/source/Maestro.Wpf/ViewModels/FlightLabelViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/FlightLabelViewModel.cs
@@ -163,9 +163,7 @@ public partial class FlightLabelViewModel : ObservableObject, IRecipient<VatsysT
             _mediator.Send(
                 new OpenInsertFlightWindowRequest(
                     FlightViewModel.DestinationIdentifier,
-                    new RelativeInsertionOptions(FlightViewModel.Callsign, RelativePosition.Before),
-                    _maestroViewModel.Flights.Where(f => f.State == State.Landed).ToArray(),
-                    _maestroViewModel.PendingFlights.ToArray()));
+                    new RelativeInsertionOptions(FlightViewModel.Callsign, RelativePosition.Before)));
         }
         catch (Exception ex)
         {
@@ -186,9 +184,7 @@ public partial class FlightLabelViewModel : ObservableObject, IRecipient<VatsysT
             _mediator.Send(
                 new OpenInsertFlightWindowRequest(
                     FlightViewModel.DestinationIdentifier,
-                    new RelativeInsertionOptions(FlightViewModel.Callsign, RelativePosition.After),
-                    _maestroViewModel.Flights.Where(f => f.State == State.Landed).ToArray(),
-                    _maestroViewModel.PendingFlights.ToArray()));
+                    new RelativeInsertionOptions(FlightViewModel.Callsign, RelativePosition.After)));
         }
         catch (Exception ex)
         {

--- a/source/Maestro.Wpf/ViewModels/InsertFlightViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/InsertFlightViewModel.cs
@@ -1,6 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Maestro.Contracts.Flights;
+using Maestro.Contracts.Sessions;
+using Maestro.Contracts.Shared;
 using Maestro.Wpf.Integrations;
 using MediatR;
 
@@ -39,21 +42,42 @@ public partial class InsertFlightViewModel : ObservableObject
     public InsertFlightViewModel(
         string airportIdentifier,
         IInsertFlightOptions options,
-        FlightDto[] landedFlights,
-        FlightDataRecord[] pendingFlights,
+        SessionDto session,
         IWindowHandle windowHandle,
         IMediator mediator,
         IErrorReporter errorReporter)
     {
         _airportIdentifier = airportIdentifier;
         _options = options;
-
-        LandedFlights = landedFlights;
-        PendingFlights = pendingFlights;
-
         _windowHandle = windowHandle;
         _mediator = mediator;
         _errorReporter = errorReporter;
+
+        ApplySession(session);
+
+        WeakReferenceMessenger.Default.Register<SessionUpdatedNotification>(this, (_, notification) =>
+        {
+            if (notification.AirportIdentifier != _airportIdentifier)
+                return;
+
+            ApplySession(notification.Session);
+        });
+    }
+
+    void ApplySession(SessionDto session)
+    {
+        LandedFlights = session.Sequence.Flights
+            .Where(f => f.State is State.Landed)
+            .ToArray();
+
+        var activatedCallsigns = new HashSet<string>(
+            session.Sequence.Flights.Select(f => f.Callsign)
+                .Concat(session.DeSequencedFlights.Select(f => f.Callsign)),
+            StringComparer.OrdinalIgnoreCase);
+
+        PendingFlights = session.FlightDataRecords
+            .Where(r => !activatedCallsigns.Contains(r.Callsign))
+            .ToArray();
     }
 
     partial void OnSelectedFlightChanged(FlightDataRecord? value)

--- a/source/Maestro.Wpf/ViewModels/MaestroViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/MaestroViewModel.cs
@@ -104,11 +104,6 @@ public partial class MaestroViewModel : ObservableObject
 
     public bool HasDesequencedFlight => DeSequencedFlights.Any();
 
-    public FlightDataRecord[] PendingFlights => FlightDataRecords
-        .Where(r => !Flights.Any(f => f.Callsign == r.Callsign) &&
-                    !DeSequencedFlights.Any(f => f.Callsign == r.Callsign))
-        .ToArray();
-
     public RunwayIntervalViewModel[] RunwayIntervals
     {
         get
@@ -454,12 +449,7 @@ public partial class MaestroViewModel : ObservableObject
             if (string.IsNullOrEmpty(AirportIdentifier))
                 return;
 
-            _mediator.Send(
-                new OpenInsertFlightWindowRequest(
-                    AirportIdentifier,
-                    options,
-                    Flights.Where(f => f.State is State.Landed).ToArray(),
-                    PendingFlights));
+            _mediator.Send(new OpenInsertFlightWindowRequest(AirportIdentifier, options));
         }
         catch (Exception ex)
         {
@@ -514,12 +504,7 @@ public partial class MaestroViewModel : ObservableObject
     {
         try
         {
-            _mediator.Send(
-                new OpenDesequencedWindowRequest(
-                    AirportIdentifier,
-                    DeSequencedFlights
-                        .Select(f => f.Callsign)
-                        .ToArray()));
+            _mediator.Send(new OpenDesequencedWindowRequest(AirportIdentifier));
         }
         catch (Exception ex)
         {

--- a/source/Maestro.Wpf/ViewModels/PendingDeparturesViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/PendingDeparturesViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Maestro.Contracts.Flights;
+using Maestro.Contracts.Sessions;
 using Maestro.Core.Extensions;
 using Maestro.Core.Infrastructure;
 using Maestro.Wpf.Integrations;
@@ -13,6 +15,7 @@ namespace Maestro.Wpf.ViewModels;
 public partial class PendingDeparturesViewModel : ObservableObject
 {
     readonly string _airportIdentifier;
+    readonly string[] _departureAirportIdentifiers;
     readonly IWindowHandle _windowHandle;
     readonly IMediator _mediator;
     readonly IErrorReporter _errorReporter;
@@ -43,19 +46,42 @@ public partial class PendingDeparturesViewModel : ObservableObject
 
     public PendingDeparturesViewModel(
         string airportIdentifier,
-        FlightDataRecord[] pendingFlights,
+        string[] departureAirportIdentifiers,
+        SessionDto session,
         IWindowHandle windowHandle,
         IMediator mediator,
         IClock clock,
         IErrorReporter errorReporter)
     {
         _airportIdentifier = airportIdentifier;
+        _departureAirportIdentifiers = departureAirportIdentifiers;
         _windowHandle = windowHandle;
         _mediator = mediator;
         _errorReporter = errorReporter;
 
-        PendingFlights = pendingFlights;
         TakeoffTime = clock.UtcNow().AddMinutes(5).Rounded();
+        ApplySession(session);
+
+        WeakReferenceMessenger.Default.Register<SessionUpdatedNotification>(this, (_, notification) =>
+        {
+            if (notification.AirportIdentifier != _airportIdentifier)
+                return;
+
+            ApplySession(notification.Session);
+        });
+    }
+
+    void ApplySession(SessionDto session)
+    {
+        var activatedCallsigns = new HashSet<string>(
+            session.Sequence.Flights.Select(f => f.Callsign)
+                .Concat(session.DeSequencedFlights.Select(f => f.Callsign)),
+            StringComparer.OrdinalIgnoreCase);
+
+        PendingFlights = session.FlightDataRecords
+            .Where(r => !activatedCallsigns.Contains(r.Callsign) &&
+                        _departureAirportIdentifiers.Contains(r.Origin, StringComparer.OrdinalIgnoreCase))
+            .ToArray();
     }
 
     partial void OnSelectedFlightChanged(FlightDataRecord? value)

--- a/source/Maestro.Wpf/ViewModels/TerminalConfigurationViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/TerminalConfigurationViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Maestro.Contracts.Runway;
 using Maestro.Contracts.Sessions;
 using Maestro.Core.Configuration;
@@ -40,8 +41,10 @@ public partial class TerminalConfigurationViewModel : ObservableObject
     [ObservableProperty]
     DateTimeOffset _firstLandingTime;
 
+    [ObservableProperty]
+    bool _hasPendingModeChange;
+
     public RunwayModeViewModel[] AvailableRunwayModes { get; }
-    public bool HasPendingModeChange { get; }
 
     public double MinimumLandingRateSeconds => 30;
     public double MaximumLandingRateSeconds => 60 * 5; // 5 Minutes
@@ -79,6 +82,18 @@ public partial class TerminalConfigurationViewModel : ObservableObject
         FirstLandingTime = firstLandingTimeForNewMode;
 
         RunwayConfigurationItems = CreateRunwayConfigurationItems(SelectedRunwayMode);
+
+        WeakReferenceMessenger.Default.Register<SessionUpdatedNotification>(this, (_, notification) =>
+        {
+            if (notification.AirportIdentifier != _airportIdentifier)
+                return;
+
+            OriginalRunwayModeIdentifier = notification.Session.Sequence.CurrentRunwayMode.Identifier;
+            HasPendingModeChange = notification.Session.Sequence.NextRunwayMode is not null;
+            LastLandingTime = notification.Session.Sequence.LastLandingTimeForCurrentMode == default
+                ? _clock.UtcNow()
+                : notification.Session.Sequence.LastLandingTimeForCurrentMode;
+        });
     }
 
     partial void OnSelectedRunwayModeIdentifierChanged(string value)


### PR DESCRIPTION
Popup windows (Insert Flight, Pending Departures, De-sequenced, Terminal Configuration) were stuck showing stale data if the session changed while they were open.

Each ViewModel now subscribes to `SessionUpdatedNotification` via `WeakReferenceMessenger` and updates its state through a shared `ApplySession` method, called by both the constructor and the notification handler. Window open requests no longer carry pre-computed flight lists — handlers fetch the session snapshot themselves.

Fixes https://github.com/YuKitsune/vMaestro/issues/163