### PR TITLE
Preserve Stable flights when scheduling around Unstable flights

### DIFF
--- a/source/Maestro.Core.Tests/Model/SequenceExtensionMethodsTests.cs
+++ b/source/Maestro.Core.Tests/Model/SequenceExtensionMethodsTests.cs
@@ -87,7 +87,7 @@ public class SequenceExtensionMethodsTests(ClockFixture clockFixture)
         flight1.LandingTime.ShouldBe(flight2.LandingTime.Add(_landingRate), "flight1 should be delayed behind flight2");
     }
 
-    [Theory(Skip = "Inaccurate behaviour")]
+    [Theory]
     [InlineData(State.Stable)]
     [InlineData(State.SuperStable)]
     public void RepositionByEstimate_WhenEtaIsEarlier_AndStableFlightIsInFront_AndNewEtaConflicts_RepositionedFlightIsMovedBehindStableFlight(State stableFlightState)
@@ -167,7 +167,7 @@ public class SequenceExtensionMethodsTests(ClockFixture clockFixture)
         stableFlight.LandingTime.ShouldBe(stableFlight.LandingEstimate, "stable flight should remain at its original time");
     }
 
-    [Theory(Skip = "Inaccurate behaviour")]
+    [Theory]
     [InlineData(State.Stable)]
     [InlineData(State.SuperStable)]
     public void RepositionByEstimate_WhenEtaIsLater_AndStableFlightIsBehind_AndNewEtaConflicts_RepositionedFlightIsMovedBehindStableFlight(State stableFlightState)
@@ -196,7 +196,7 @@ public class SequenceExtensionMethodsTests(ClockFixture clockFixture)
         sequence.NumberInSequence(stableFlight).ShouldBe(2);
 
         // Act: Update unstableFlight's estimate to be 2 minutes before the stable flight (causing conflict with 3-minute spacing)
-        unstableFlight.UpdateFeederFixEstimate(_time.AddMinutes(7).Subtract(_defaultTtg));
+        unstableFlight.UpdateFeederFixEstimate(_time.AddMinutes(8).Subtract(_defaultTtg));
         sequence.RepositionByLandingEstimate(unstableFlight);
 
         // Assert: unstableFlight should be moved behind the stable flight due to conflict
@@ -320,7 +320,7 @@ public class SequenceExtensionMethodsTests(ClockFixture clockFixture)
 
         // Act: Update unstableFlight's estimate to be earlier than stableFlight but close enough to conflict (within landing rate)
         unstableFlight.UpdateFeederFixEstimate(_time.AddMinutes(4).Subtract(_defaultTtg));
-        sequence.RepositionByLandingEstimate(unstableFlight);
+        sequence.RepositionByLandingEstimate(unstableFlight, forceRescheduleStable: true);
 
         // Assert: unstableFlight should be moved in front and land at its estimate, stable flight should be displaced
         sequence.NumberInSequence(unstableFlight).ShouldBe(1, "unstable flight should now be first in sequence");
@@ -363,7 +363,7 @@ public class SequenceExtensionMethodsTests(ClockFixture clockFixture)
 
         // Act: Update unstableFlight's estimate to be 2 minutes before the stable flight (causing conflict with 3-minute spacing)
         unstableFlight.UpdateFeederFixEstimate(_time.AddMinutes(8).Subtract(_defaultTtg));
-        sequence.RepositionByLandingEstimate(unstableFlight);
+        sequence.RepositionByLandingEstimate(unstableFlight, forceRescheduleStable: true);
 
         // Assert: unstableFlight should remain in front and land at its new estimate, stable flight should be displaced
         sequence.NumberInSequence(unstableFlight).ShouldBe(1, "unstable flight should remain first in sequence");

--- a/source/Maestro.Core.Tests/Model/SequenceTests.cs
+++ b/source/Maestro.Core.Tests/Model/SequenceTests.cs
@@ -528,6 +528,122 @@ public class SequenceTests(ClockFixture clockFixture)
             "the new rate becomes the current runway mode after the change time is reached");
     }
 
+    [Theory]
+    [InlineData(State.Stable)]
+    [InlineData(State.SuperStable)]
+    public void Schedule_WhenUnstableFlightAheadHasEtaChange_StableFlightBehindDoesNotMove(State stableFlightState)
+    {
+        // Arrange
+        var airportConfig = CreateSingleRunwayConfiguration("34L", _acceptanceRate);
+        var sequence = new SequenceBuilder(airportConfig)
+            .WithClock(clockFixture.Instance)
+            .Build();
+
+        var unstableFlight = new FlightBuilder("ABC123")
+            .WithLandingEstimate(_time.AddMinutes(10))
+            .WithRunway("34L")
+            .WithState(State.Unstable)
+            .Build();
+
+        var stableFlight = new FlightBuilder("DEF456")
+            .WithLandingEstimate(_time.AddMinutes(15))
+            .WithRunway("34L")
+            .WithState(stableFlightState)
+            .Build();
+
+        sequence.Insert(0, unstableFlight);
+        sequence.Insert(1, stableFlight);
+
+        var stableLandingTimeBefore = stableFlight.LandingTime;
+        stableLandingTimeBefore.ShouldBe(_time.AddMinutes(15));
+
+        // Act: unstable flight's ETA moves earlier, then sequence is recomputed without forcing
+        unstableFlight.UpdateLandingEstimate(_time.AddMinutes(8));
+        sequence.Schedule(0);
+
+        // Assert
+        stableFlight.LandingTime.ShouldBe(stableLandingTimeBefore,
+            $"{stableFlightState} flight's landing time must not change when an unstable flight ahead recomputes");
+        unstableFlight.LandingTime.ShouldBe(_time.AddMinutes(8),
+            "unstable flight takes its new estimate");
+    }
+
+    [Fact]
+    public void Schedule_WhenUnstableFlightConflictsWithStableBehind_UnstableIsMovedBehindStable()
+    {
+        // Arrange
+        var airportConfig = CreateSingleRunwayConfiguration("34L", _acceptanceRate);
+        var sequence = new SequenceBuilder(airportConfig)
+            .WithClock(clockFixture.Instance)
+            .Build();
+
+        var unstableFlight = new FlightBuilder("ABC123")
+            .WithLandingEstimate(_time.AddMinutes(10))
+            .WithRunway("34L")
+            .WithState(State.Unstable)
+            .Build();
+
+        var stableFlight = new FlightBuilder("DEF456")
+            .WithLandingEstimate(_time.AddMinutes(15))
+            .WithRunway("34L")
+            .WithState(State.Stable)
+            .Build();
+
+        sequence.Insert(0, unstableFlight);
+        sequence.Insert(1, stableFlight);
+
+        var stableLandingTimeBefore = stableFlight.LandingTime;
+
+        // Act: unstable flight slows down into conflict with stable behind it
+        unstableFlight.UpdateLandingEstimate(_time.AddMinutes(14));
+        sequence.Schedule(0);
+
+        // Assert
+        stableFlight.LandingTime.ShouldBe(stableLandingTimeBefore,
+            "stable flight's landing time must not move to accommodate a delayed unstable flight");
+        sequence.IndexOf(stableFlight).ShouldBe(0,
+            "stable flight should now lead the sequence");
+        sequence.IndexOf(unstableFlight).ShouldBe(1,
+            "unstable flight should be pushed behind the stable flight");
+        unstableFlight.LandingTime.ShouldBe(stableFlight.LandingTime.Add(_acceptanceRate),
+            "unstable flight must be separated from the stable flight by the acceptance rate");
+    }
+
+    [Fact]
+    public void Schedule_WithForceRescheduleStable_RecomputesStableFlights()
+    {
+        // Arrange
+        var airportConfig = CreateSingleRunwayConfiguration("34L", _acceptanceRate);
+        var sequence = new SequenceBuilder(airportConfig)
+            .WithClock(clockFixture.Instance)
+            .Build();
+
+        var unstableFlight = new FlightBuilder("ABC123")
+            .WithLandingEstimate(_time.AddMinutes(10))
+            .WithRunway("34L")
+            .WithState(State.Unstable)
+            .Build();
+
+        var stableFlight = new FlightBuilder("DEF456")
+            .WithLandingEstimate(_time.AddMinutes(15))
+            .WithRunway("34L")
+            .WithState(State.Stable)
+            .Build();
+
+        sequence.Insert(0, unstableFlight);
+        sequence.Insert(1, stableFlight);
+
+        // Act: change unstable ETA, then force a reschedule of stable flights
+        unstableFlight.UpdateLandingEstimate(_time.AddMinutes(8));
+        sequence.Schedule(0, forceRescheduleStable: true);
+
+        // Assert
+        unstableFlight.LandingTime.ShouldBe(_time.AddMinutes(8),
+            "unstable flight takes its new estimate");
+        stableFlight.LandingTime.ShouldBe(_time.AddMinutes(15),
+            "stable flight retains its earlier landing estimate when unconstrained");
+    }
+
     static AirportConfiguration CreateSingleRunwayConfiguration(string runwayIdentifier, TimeSpan acceptanceRate)
     {
         return new AirportConfigurationBuilder("YSSY")

--- a/source/Maestro.Core/Handlers/ChangeFeederFixEstimateRequestHandler.cs
+++ b/source/Maestro.Core/Handlers/ChangeFeederFixEstimateRequestHandler.cs
@@ -50,7 +50,7 @@ public class ChangeFeederFixEstimateRequestHandler(
 
             flight.UpdateFeederFixEstimate(request.NewFeederFixEstimate, manual: true);
 
-            session.Sequence.RepositionByLandingEstimate(flight);
+            session.Sequence.RepositionByLandingEstimate(flight, forceRescheduleStable: true);
             if (flight.State is State.Unstable)
                 flight.SetState(airportConfiguration.ManualInteractionState, clock); // TODO: Make configurable
 

--- a/source/Maestro.Core/Handlers/ChangeRunwayRequestHandler.cs
+++ b/source/Maestro.Core/Handlers/ChangeRunwayRequestHandler.cs
@@ -91,7 +91,7 @@ public class ChangeRunwayRequestHandler(
             if (flight.State is State.Unstable)
                 flight.SetState(airportConfiguration.ManualInteractionState, clock);
 
-            sequence.RepositionByFeederFixEstimate(flight);
+            sequence.RepositionByFeederFixEstimate(flight, forceRescheduleStable: true);
 
             logger.Information("{Callsign} runway changed to {Runway}", flight.Callsign, request.RunwayIdentifier);
 

--- a/source/Maestro.Core/Handlers/ManualDelayRequestHandler.cs
+++ b/source/Maestro.Core/Handlers/ManualDelayRequestHandler.cs
@@ -48,7 +48,7 @@ public class ManualDelayRequestHandler(
             // Re-schedule the flight
             // This will move it forward if the delay exceeds the maximum delay
             // TODO: Should this be a different method?
-            sequence.Schedule(index);
+            sequence.Schedule(index, forceRescheduleStable: true);
 
             logger.Information("Set maximum delay for {Callsign} to {MaximumDelay}", request.Callsign, maximumDelay);
 

--- a/source/Maestro.Core/Handlers/MoveFlightRequestHandler.cs
+++ b/source/Maestro.Core/Handlers/MoveFlightRequestHandler.cs
@@ -86,7 +86,7 @@ public class MoveFlightRequestHandler(
             if (flight.State == State.Unstable)
                 flight.SetState(airportConfiguration.ManualInteractionState, clock);
 
-            sequence.Move(flight, newIndex);
+            sequence.Move(flight, newIndex, forceRescheduleStable: true);
 
             logger.Information("Flight {Callsign} moved to {NewLandingTime}", flight.Callsign, flight.LandingTime);
 

--- a/source/Maestro.Core/Handlers/RecomputeRequestHandler.cs
+++ b/source/Maestro.Core/Handlers/RecomputeRequestHandler.cs
@@ -99,7 +99,7 @@ public class RecomputeRequestHandler(
             // Reset the state
             flight.SetState(State.Unstable, clock);
 
-            sequence.RepositionByLandingEstimate(flight);
+            sequence.RepositionByLandingEstimate(flight, forceRescheduleStable: true);
             flight.UpdateStateBasedOnTime(clock, airportConfiguration);
 
             logger.Information("{Callsign} recomputed", flight.Callsign);

--- a/source/Maestro.Core/Model/Sequence.cs
+++ b/source/Maestro.Core/Model/Sequence.cs
@@ -71,7 +71,7 @@ public class Sequence
         lock (_gate)
         {
             CurrentRunwayMode = runwayMode;
-            Schedule(0);
+            Schedule(0, forceRescheduleStable: true);
         }
     }
 
@@ -96,7 +96,7 @@ public class Sequence
                 firstLandingTimeForNewMode);
 
             var recomputeIndex = IndexOf(recomputeBoundary);
-            Schedule(recomputeIndex);
+            Schedule(recomputeIndex, forceRescheduleStable: true);
         }
     }
 
@@ -114,7 +114,7 @@ public class Sequence
             PendingConfigurationChange = new LandingRatesChange(newLandingRates, ratesChangeTime);
 
             var recomputeIndex = IndexOf(ratesChangeTime);
-            Schedule(recomputeIndex);
+            Schedule(recomputeIndex, forceRescheduleStable: true);
         }
     }
 
@@ -136,7 +136,7 @@ public class Sequence
 
             PendingConfigurationChange = null;
 
-            Schedule(recomputeIndex);
+            Schedule(recomputeIndex, forceRescheduleStable: true);
         }
     }
 
@@ -264,7 +264,7 @@ public class Sequence
         {
             ValidateInsertionBetweenImmovableFlights(index, flight.AssignedRunwayIdentifier);
             _flights.Insert(index, flight);
-            Schedule(index);
+            Schedule(index, forceRescheduleStable: true);
         }
     }
 
@@ -342,7 +342,7 @@ public class Sequence
         }
     }
 
-    public void Move(Flight flight, int newIndex)
+    public void Move(Flight flight, int newIndex, bool forceRescheduleStable = false)
     {
         lock (_gate)
         {
@@ -363,7 +363,7 @@ public class Sequence
             }
 
             var recomputeIndex = Math.Min(newIndex, currentIndex);
-            Schedule(recomputeIndex);
+            Schedule(recomputeIndex, forceRescheduleStable);
         }
     }
 
@@ -425,7 +425,7 @@ public class Sequence
 
             _flights.RemoveAt(index);
 
-            Schedule(index);
+            Schedule(index, forceRescheduleStable: true);
         }
     }
 
@@ -439,7 +439,7 @@ public class Sequence
             _slots.Add(slot);
 
             var recomputeIndex = IndexOf(start);
-            Schedule(recomputeIndex);
+            Schedule(recomputeIndex, forceRescheduleStable: true);
 
             return id;
         }
@@ -461,7 +461,7 @@ public class Sequence
             // BUG: If a flight is scheduled to land after the start time, but estimated to land before it, they need
             //  to be recomputed. Maybe this is okay?
             var rescheduleIndex = IndexOf(start);
-            Schedule(rescheduleIndex);
+            Schedule(rescheduleIndex, forceRescheduleStable: true);
         }
     }
 
@@ -476,7 +476,7 @@ public class Sequence
             _slots.Remove(slot);
 
             var rescheduleIndex = IndexOf(slot.StartTime);
-            Schedule(rescheduleIndex);
+            Schedule(rescheduleIndex, forceRescheduleStable: true);
         }
     }
 
@@ -545,7 +545,7 @@ public class Sequence
     ///     When <c>false</c>, flights that are not <see cref="State.Unstable"/> will not be affected. Any <see cref="State.Unstable"/> flights
     ///     in conflict with a non-<see cref="State.Unstable"/> flight will be moved behind them as to not adjust their landing times.
     /// </param>
-    public void Schedule(int startIndex)
+    public void Schedule(int startIndex, bool forceRescheduleStable = false)
     {
         lock (_gate)
         {
@@ -569,6 +569,12 @@ public class Sequence
 
                 var currentFlight = flightItem.Flight;
                 if (currentFlight.State is State.Landed or State.Frozen)
+                {
+                    continue;
+                }
+
+                // Stable and SuperStable flights should not be rescheduled unless forced
+                if (!forceRescheduleStable && currentFlight.State is State.Stable or State.SuperStable)
                 {
                     continue;
                 }
@@ -791,9 +797,10 @@ public class Sequence
                     case SlotSequenceItem slotSequenceItem when slotSequenceItem.Slot.RunwayIdentifiers.Contains(referenceRunway.Identifier):
                         return slotSequenceItem.Slot.StartTime;
 
-                    // Landed and Frozen flights cannot move
+                    // Landed and Frozen flights cannot move.
+                    // Stable and SuperStable flights cannot move unless forced.
                     // Any other flight can be moved, so we'll ignore them and rely on the next iteration to re-calculate their STA
-                    case FlightSequenceItem { Flight.State: State.Landed or State.Frozen } flightSequenceItem:
+                    case FlightSequenceItem flightSequenceItem when IsImmovable(flightSequenceItem.Flight):
                     {
                         var requiredSeparation = GetRequiredSeparation(flightSequenceItem, referenceRunway, runwayMode);
                         if (requiredSeparation == TimeSpan.Zero)
@@ -804,6 +811,17 @@ public class Sequence
 
                     default: return null;
                 }
+            }
+
+            bool IsImmovable(Flight flight)
+            {
+                if (flight.State is State.Landed or State.Frozen)
+                    return true;
+
+                if (!forceRescheduleStable && flight.State is State.Stable or State.SuperStable)
+                    return true;
+
+                return false;
             }
 
             DateTimeOffset? GetEarliestLandingTimeFromItem(ISequenceItem item, RunwayMode runwayMode, Runway referenceRunway)

--- a/source/Maestro.Core/Model/SequenceExtensionMethods.cs
+++ b/source/Maestro.Core/Model/SequenceExtensionMethods.cs
@@ -6,7 +6,8 @@ public static class SequenceExtensionMethods
 {
     public static void RepositionByFeederFixEstimate(
         this Sequence sequence,
-        Flight flight)
+        Flight flight,
+        bool forceRescheduleStable = false)
     {
         var newIndex = sequence.FindIndex(
             f => f.FeederFixEstimate.IsAfter(flight.FeederFixEstimate));
@@ -14,12 +15,13 @@ public static class SequenceExtensionMethods
         if (newIndex == -1)
             newIndex = sequence.Flights.Count;
 
-        sequence.Move(flight, newIndex);
+        sequence.Move(flight, newIndex, forceRescheduleStable);
     }
 
     public static void RepositionByLandingEstimate(
         this Sequence sequence,
-        Flight flight)
+        Flight flight,
+        bool forceRescheduleStable = false)
     {
         var newIndex = sequence.FindIndex(
             f => f.LandingEstimate.IsAfter(flight.LandingEstimate));
@@ -27,6 +29,6 @@ public static class SequenceExtensionMethods
         if (newIndex == -1)
             newIndex = sequence.Flights.Count;
 
-        sequence.Move(flight, newIndex);
+        sequence.Move(flight, newIndex, forceRescheduleStable);
     }
 }


### PR DESCRIPTION
Stable and SuperStable flights no longer move when an Unstable flight ahead of them changes. Unstable flights that conflict with a Stable flight are pushed behind it instead.

Fixes #167
Fixes #168