### PR TITLE
fix: Re-assign Stable flights to new mode runways on runway mode change

### DIFF
--- a/source/Maestro.Core.Tests/Handlers/ChangeRunwayModeRequestHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/ChangeRunwayModeRequestHandlerTests.cs
@@ -621,39 +621,38 @@ public class ChangeRunwayModeRequestHandlerTests(ClockFixture clockFixture)
     }
 
     [Fact]
-    public async Task FlightsInNewMode_OffModeFlightSeparatedByOffModeRate()
+    public async Task StableFlights_WithOldModeRunway_AreReassignedToNewMode()
     {
         var now = clockFixture.Instance.UtcNow();
 
         // Arrange
-        const int offModeRateSeconds = 300;
+        const int acceptanceRateSeconds = 180;
 
         var airportConfiguration = new AirportConfigurationBuilder("YSSY")
             .WithRunways("34L", "34R", "16L", "16R")
             .WithFeederFixes("RIVET", "BOREE")
             .WithRunwayMode("34IVA",
-                new RunwayConfiguration { Identifier = "34L", ApproachType = "", LandingRateSeconds = 180, FeederFixes = ["RIVET"] },
-                new RunwayConfiguration { Identifier = "34R", ApproachType = "", LandingRateSeconds = 180, FeederFixes = ["BOREE"] })
+                new RunwayConfiguration { Identifier = "34L", ApproachType = "", LandingRateSeconds = acceptanceRateSeconds, FeederFixes = ["RIVET"] },
+                new RunwayConfiguration { Identifier = "34R", ApproachType = "", LandingRateSeconds = acceptanceRateSeconds, FeederFixes = ["BOREE"] })
             .WithRunwayMode(new RunwayModeConfiguration
             {
                 Identifier = "16IVA",
-                OffModeSeparationSeconds = offModeRateSeconds,
                 Runways =
                 [
-                    new RunwayConfiguration { Identifier = "16L", ApproachType = "", LandingRateSeconds = 180, FeederFixes = ["BOREE"] },
-                    new RunwayConfiguration { Identifier = "16R", ApproachType = "", LandingRateSeconds = 180, FeederFixes = ["RIVET"] }
+                    new RunwayConfiguration { Identifier = "16L", ApproachType = "", LandingRateSeconds = acceptanceRateSeconds, FeederFixes = ["BOREE"] },
+                    new RunwayConfiguration { Identifier = "16R", ApproachType = "", LandingRateSeconds = acceptanceRateSeconds, FeederFixes = ["RIVET"] }
                 ]
             })
             .Build();
 
-        // flight1 lands in the new mode on 16L
+        // flight1 is unstable with a BOREE feeder fix — gets assigned to 16L
         var flight1 = new FlightBuilder("QFA1")
             .WithLandingEstimate(now.AddMinutes(27))
             .WithLandingTime(now.AddMinutes(27))
             .WithFeederFix("BOREE")
             .Build();
 
-        // flight2 is stable on 34L (off-mode in 16IVA) — it retains its runway but must be separated by the off-mode rate
+        // flight2 is stable on 34L (old mode) — should be re-assigned to the new mode on mode change
         var flight2 = new FlightBuilder("QFA2")
             .WithLandingEstimate(now.AddMinutes(27))
             .WithLandingTime(now.AddMinutes(27))
@@ -680,11 +679,11 @@ public class ChangeRunwayModeRequestHandlerTests(ClockFixture clockFixture)
         var runwayModeDto = new RunwayModeDto(
             "16IVA",
             [
-                new RunwayDto("16L", string.Empty, 180, []),
-                new RunwayDto("16R", string.Empty, 180, [])
+                new RunwayDto("16L", string.Empty, acceptanceRateSeconds, []),
+                new RunwayDto("16R", string.Empty, acceptanceRateSeconds, [])
             ],
             DefaultDependencyRateSeconds,
-            offModeRateSeconds);
+            DefaultOffModeSeconds);
 
         var request = new ChangeRunwayModeRequest(
             "YSSY",
@@ -696,13 +695,12 @@ public class ChangeRunwayModeRequestHandlerTests(ClockFixture clockFixture)
         await handler.Handle(request, CancellationToken.None);
 
         // Assert
+        var firstLandingTimeForNewMode = now.AddMinutes(25);
         flight1.AssignedRunwayIdentifier.ShouldBe("16L", "QFA1 (BOREE) should be assigned to 16L in the new mode");
-        flight2.AssignedRunwayIdentifier.ShouldBe("34L", "stable QFA2 should retain its off-mode runway 34L");
-
-        var actualSeparation = flight2.LandingTime - flight1.LandingTime;
-        actualSeparation.ShouldBeGreaterThanOrEqualTo(
-            TimeSpan.FromSeconds(offModeRateSeconds),
-            "off-mode flight should be separated from in-mode flight by the off-mode rate");
+        flight2.AssignedRunwayIdentifier.ShouldBeOneOf("16L", "16R",
+            "stable QFA2 should be re-assigned to the new mode — its old 34L runway is no longer valid");
+        flight2.LandingTime.ShouldBeGreaterThanOrEqualTo(firstLandingTimeForNewMode,
+            "QFA2 must land at or after the new mode start time");
     }
 
     [Fact]

--- a/source/Maestro.Core/Model/Sequence.cs
+++ b/source/Maestro.Core/Model/Sequence.cs
@@ -71,7 +71,7 @@ public class Sequence
         lock (_gate)
         {
             CurrentRunwayMode = runwayMode;
-            Schedule(0, forceRescheduleStable: true);
+            Schedule(0, forceRescheduleStable: true, reassignOffModeRunways: true);
         }
     }
 
@@ -96,7 +96,7 @@ public class Sequence
                 firstLandingTimeForNewMode);
 
             var recomputeIndex = IndexOf(recomputeBoundary);
-            Schedule(recomputeIndex, forceRescheduleStable: true);
+            Schedule(recomputeIndex, forceRescheduleStable: true, reassignOffModeRunways: true);
         }
     }
 
@@ -125,6 +125,8 @@ public class Sequence
             if (PendingConfigurationChange is null)
                 return;
 
+            var isTerminalChange = PendingConfigurationChange is TerminalConfigurationChange;
+
             var recomputeTime = PendingConfigurationChange switch
             {
                 TerminalConfigurationChange terminalConfigurationChange => terminalConfigurationChange.FirstLandingTimeInNewMode,
@@ -136,7 +138,7 @@ public class Sequence
 
             PendingConfigurationChange = null;
 
-            Schedule(recomputeIndex, forceRescheduleStable: true);
+            Schedule(recomputeIndex, forceRescheduleStable: true, reassignOffModeRunways: isTerminalChange);
         }
     }
 
@@ -545,7 +547,12 @@ public class Sequence
     ///     When <c>false</c>, flights that are not <see cref="State.Unstable"/> will not be affected. Any <see cref="State.Unstable"/> flights
     ///     in conflict with a non-<see cref="State.Unstable"/> flight will be moved behind them as to not adjust their landing times.
     /// </param>
-    public void Schedule(int startIndex, bool forceRescheduleStable = false)
+    /// <param name="reassignOffModeRunways">
+    ///     When <c>true</c>, Stable and SuperStable flights whose assigned runway is not in the current runway mode will
+    ///     be re-assigned to a runway in the current mode. Use when the runway mode itself has changed.
+    ///     When <c>false</c>, such flights retain their off-mode runway assignment.
+    /// </param>
+    public void Schedule(int startIndex, bool forceRescheduleStable = false, bool reassignOffModeRunways = false)
     {
         lock (_gate)
         {
@@ -596,7 +603,8 @@ public class Sequence
                 var runwayOptions = GetRunways(
                     _airportConfiguration,
                     currentFlight,
-                    currentRunwayMode);
+                    currentRunwayMode,
+                    reassignOffModeRunways);
 
                 log.Debug("Schedule {Callsign}: {Count} runway options found", currentFlight.Callsign, runwayOptions.Length);
 
@@ -1064,7 +1072,7 @@ public class Sequence
     record RunwayOption(string RunwayIdentifier, string ApproachType, TimeSpan RequiredSeparation, TerminalTrajectory Trajectory);
 
     // TODO: Extract this out into a separate service so we can test it
-    RunwayOption[] GetRunways(AirportConfiguration airportConfiguration, Flight flight, RunwayMode runwayMode)
+    RunwayOption[] GetRunways(AirportConfiguration airportConfiguration, Flight flight, RunwayMode runwayMode, bool reassignOffModeRunways = false)
     {
         // If a runway is assigned, and the flight is stable, leave it as-is
         // For stable flights, preserve both the runway AND the approach type
@@ -1077,10 +1085,14 @@ public class Sequence
                 return [new RunwayOption(runway.Identifier, flight.ApproachType, runway.AcceptanceRate, trajectory)];
             }
 
-            // Runway is off-mode, create an ad-hoc option
-            var separation = runwayMode.OffModeSeparation;
-            var offModeTrajectory = _trajectoryService.GetTrajectory(flight, flight.AssignedRunwayIdentifier, flight.ApproachType, [], UpperWind);
-            return [new RunwayOption(flight.AssignedRunwayIdentifier, flight.ApproachType, separation, offModeTrajectory)];
+            // Runway is off-mode. During a runway mode change, re-assign to a runway in the new mode.
+            // Otherwise preserve the off-mode assignment.
+            if (!reassignOffModeRunways)
+            {
+                var separation = runwayMode.OffModeSeparation;
+                var offModeTrajectory = _trajectoryService.GetTrajectory(flight, flight.AssignedRunwayIdentifier, flight.ApproachType, [], UpperWind);
+                return [new RunwayOption(flight.AssignedRunwayIdentifier, flight.ApproachType, separation, offModeTrajectory)];
+            }
         }
 
         var possibleRunways = new HashSet<RunwayOption>();


### PR DESCRIPTION
Fixes #173.

When a runway mode change was scheduled, Stable flights landing after the change time were not being re-assigned to runways in the new mode. They remained on their original runways (now off-mode) and had off-mode separation applied.

Stable flights are now re-assigned to the appropriate runways in the new mode when a mode change is scheduled or takes effect, consistent with how Unstable flights are handled.