### PR TITLE
fix: prevent removed flight from reappearing on the ladder after landing

### DIFF
--- a/source/Maestro.Core.Tests/Handlers/FlightPlanUpdatedHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/FlightPlanUpdatedHandlerTests.cs
@@ -397,6 +397,67 @@ public class FlightPlanUpdatedHandlerTests(ClockFixture clockFixture)
     }
 
     [Fact]
+    public async Task WhenAFlightPlanIsUpdated_AndAircraftIsOnGround_ActivateFlightRequestIsNotSent()
+    {
+        // Arrange — simulates a landed flight whose FDR is still Active during taxi.
+        // Without this guard, removing the flight then receiving another FDR would reactivate it.
+        var airportConfiguration = GetDefaultAirportConfiguration();
+        var clock = clockFixture.Instance;
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
+
+        var onGroundPosition = new FlightPosition(
+            new Coordinate(0, 0),
+            0,
+            VerticalTrack.Maintaining,
+            0,
+            true);
+
+        var mediator = Substitute.For<IMediator>();
+        var notification = new FlightPlanUpdatedNotification(
+            "QFA123", "B738", AircraftCategory.Jet, WakeCategory.Medium,
+            "YMML", "YSSY", clock.UtcNow().AddHours(-2), TimeSpan.FromHours(1.5),
+            FlightPlanState.Active,
+            onGroundPosition,
+            [new FixEstimate("RIVET", clock.UtcNow().AddMinutes(-5))]);
+
+        var handler = GetHandler(sessionManager, clock, mediator: mediator);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await mediator.DidNotReceive().Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WhenAFlightPlanIsUpdated_AndAllEstimatesAreInThePast_ActivateFlightRequestIsNotSent()
+    {
+        // Arrange — covers the case where Position is unavailable but the route is fully overflown.
+        var airportConfiguration = GetDefaultAirportConfiguration();
+        var clock = clockFixture.Instance;
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
+
+        var mediator = Substitute.For<IMediator>();
+        var notification = new FlightPlanUpdatedNotification(
+            "QFA123", "B738", AircraftCategory.Jet, WakeCategory.Medium,
+            "YMML", "YSSY", clock.UtcNow().AddHours(-2), TimeSpan.FromHours(1.5),
+            FlightPlanState.Active,
+            Position: null,
+            [
+                new FixEstimate("RIVET", clock.UtcNow().AddMinutes(-20)),
+                new FixEstimate("YSSY", clock.UtcNow().AddMinutes(-2))
+            ]);
+
+        var handler = GetHandler(sessionManager, clock, mediator: mediator);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await mediator.DidNotReceive().Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task WhenAFlightPlanIsUpdated_AndEstimatedFlightTimeIsBelowMinimum_ActivateFlightRequestIsNotSent()
     {
         // Arrange

--- a/source/Maestro.Core/Handlers/FlightPlanUpdatedHandler.cs
+++ b/source/Maestro.Core/Handlers/FlightPlanUpdatedHandler.cs
@@ -86,6 +86,12 @@ public class FlightPlanUpdatedHandler(
         if (config.DepartureAirports.Any(d => d.Identifier == record.Origin))
             return config.AutoActivateDepartures;
 
+        // Don't reactivate a flight that has already touched down. After landing the FDR
+        // continues to report Active during taxi until it transitions to STATE_FINISHED,
+        // which would otherwise re-insert a flight that a controller has just removed.
+        if (record.Position?.IsOnGround == true)
+            return false;
+
         var landingEstimate = record.Estimates.LastOrDefault()?.Estimate;
         if (landingEstimate is not null)
         {
@@ -97,9 +103,12 @@ public class FlightPlanUpdatedHandler(
         if (record.EstimatedFlightTime < TimeSpan.FromMinutes(config.MinimumAutoActivationFlightTimeMinutes))
             return false;
 
-        if (record.State is FlightPlanState.Active)
-            return true;
+        if (record.State is not FlightPlanState.Active)
+            return false;
 
-        return false;
+        // Require at least one future-dated route estimate. Once the route is fully overflown
+        // the FDR can still report Active briefly, and activating without a future estimate
+        // produces a flight whose entire trajectory is in the past.
+        return record.Estimates.Any(e => e.Estimate > now);
     }
 }


### PR DESCRIPTION
Closes #185.

## Summary

- Bail out of `ShouldAutoActivate` when `record.Position?.IsOnGround == true`.
- For `FlightPlanState.Active`, require at least one future-dated route estimate before activating.

Together these stop `FlightPlanUpdatedHandler` from re-inserting a flight that the controller manually removed while the FDR is still reporting Active during taxi-in.

## Test plan

- [x] `dotnet test source/Maestro.Core.Tests/Maestro.Core.Tests.csproj` — 467 pass, 0 fail.
- [x] Added `WhenAFlightPlanIsUpdated_AndAircraftIsOnGround_ActivateFlightRequestIsNotSent`.
- [x] Added `WhenAFlightPlanIsUpdated_AndAllEstimatesAreInThePast_ActivateFlightRequestIsNotSent`.