### PR TITLE
fix: prevent landed flights and go-arounds from reappearing on the ladder

### DIFF
--- a/source/Maestro.Core.Tests/Handlers/FlightPlanUpdatedHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/FlightPlanUpdatedHandlerTests.cs
@@ -432,7 +432,7 @@ public class FlightPlanUpdatedHandlerTests(ClockFixture clockFixture)
     [Fact]
     public async Task WhenAFlightPlanIsUpdated_AndAllEstimatesAreInThePast_ActivateFlightRequestIsNotSent()
     {
-        // Arrange — covers the case where Position is unavailable but the route is fully overflown.
+        // Arrange — an airborne FDR whose route is fully overflown must not reactivate.
         var airportConfiguration = GetDefaultAirportConfiguration();
         var clock = clockFixture.Instance;
         var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
@@ -442,10 +442,41 @@ public class FlightPlanUpdatedHandlerTests(ClockFixture clockFixture)
             "QFA123", "B738", AircraftCategory.Jet, WakeCategory.Medium,
             "YMML", "YSSY", clock.UtcNow().AddHours(-2), TimeSpan.FromHours(1.5),
             FlightPlanState.Active,
-            Position: null,
+            _position,
             [
                 new FixEstimate("RIVET", clock.UtcNow().AddMinutes(-20)),
                 new FixEstimate("YSSY", clock.UtcNow().AddMinutes(-2))
+            ]);
+
+        var handler = GetHandler(sessionManager, clock, mediator: mediator);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await mediator.DidNotReceive().Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WhenAFlightPlanIsUpdated_AndPositionIsNull_ActivateFlightRequestIsNotSent()
+    {
+        // Arrange — the FDR has no coupled track (typical for aircraft parked at the gate
+        // where CoupledTrack is null). Without a live position report we cannot confirm the
+        // aircraft is airborne, so an arrival must not auto-activate even if the residual
+        // route estimates are future-dated (e.g. after a callsign reuse).
+        var airportConfiguration = GetDefaultAirportConfiguration();
+        var clock = clockFixture.Instance;
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
+
+        var mediator = Substitute.For<IMediator>();
+        var notification = new FlightPlanUpdatedNotification(
+            "QFA123", "B738", AircraftCategory.Jet, WakeCategory.Medium,
+            "YMML", "YSSY", clock.UtcNow().AddHours(-1), TimeSpan.FromHours(1.5),
+            FlightPlanState.Active,
+            Position: null,
+            [
+                new FixEstimate("RIVET", clock.UtcNow().AddMinutes(30)),
+                new FixEstimate("YSSY", clock.UtcNow().AddMinutes(50))
             ]);
 
         var handler = GetHandler(sessionManager, clock, mediator: mediator);

--- a/source/Maestro.Core.Tests/Handlers/FlightPlanUpdatedHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/FlightPlanUpdatedHandlerTests.cs
@@ -489,6 +489,89 @@ public class FlightPlanUpdatedHandlerTests(ClockFixture clockFixture)
     }
 
     [Fact]
+    public async Task WhenAFlightPlanIsUpdated_AndFeederFixHasBeenOverflown_ActivateFlightRequestIsNotSent()
+    {
+        // Arrange — aircraft is inside the TMA (past the feeder fix) with only the destination
+        // fix remaining. It must not auto-activate: it was already removed from the sequence
+        // while absorbing delay on final and the controller must reinsert it manually.
+        var airportConfiguration = GetDefaultAirportConfiguration();
+        var clock = clockFixture.Instance;
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
+
+        var mediator = Substitute.For<IMediator>();
+        var notification = new FlightPlanUpdatedNotification(
+            "QFA123", "B738", AircraftCategory.Jet, WakeCategory.Medium,
+            "YMML", "YSSY", clock.UtcNow().AddHours(-1), TimeSpan.FromHours(1.5),
+            FlightPlanState.Active,
+            _position,
+            [new FixEstimate("YSSY", clock.UtcNow().AddMinutes(5))]);
+
+        var handler = GetHandler(sessionManager, clock, mediator: mediator);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await mediator.DidNotReceive().Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WhenAFlightPlanIsUpdated_AndFeederFixEstimateIsInThePast_ActivateFlightRequestIsNotSent()
+    {
+        // Arrange — feeder fix still in the route but its estimate has slipped into the past.
+        var airportConfiguration = GetDefaultAirportConfiguration();
+        var clock = clockFixture.Instance;
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
+
+        var mediator = Substitute.For<IMediator>();
+        var notification = new FlightPlanUpdatedNotification(
+            "QFA123", "B738", AircraftCategory.Jet, WakeCategory.Medium,
+            "YMML", "YSSY", clock.UtcNow().AddHours(-1), TimeSpan.FromHours(1.5),
+            FlightPlanState.Active,
+            _position,
+            [
+                new FixEstimate("RIVET", clock.UtcNow().AddMinutes(-2)),
+                new FixEstimate("YSSY", clock.UtcNow().AddMinutes(10))
+            ]);
+
+        var handler = GetHandler(sessionManager, clock, mediator: mediator);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await mediator.DidNotReceive().Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WhenAFlightPlanIsUpdated_AndNoFeederFixInFlightPlan_ActivateFlightRequestIsNotSent()
+    {
+        // Arrange — route contains no configured feeder fix (e.g. non-standard direct routing).
+        var airportConfiguration = GetDefaultAirportConfiguration();
+        var clock = clockFixture.Instance;
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
+
+        var mediator = Substitute.For<IMediator>();
+        var notification = new FlightPlanUpdatedNotification(
+            "QFA123", "B738", AircraftCategory.Jet, WakeCategory.Medium,
+            "YMML", "YSSY", clock.UtcNow().AddHours(-1), TimeSpan.FromHours(1.5),
+            FlightPlanState.Active,
+            _position,
+            [
+                new FixEstimate("SOMEFIX", clock.UtcNow().AddMinutes(30)),
+                new FixEstimate("YSSY", clock.UtcNow().AddMinutes(50))
+            ]);
+
+        var handler = GetHandler(sessionManager, clock, mediator: mediator);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await mediator.DidNotReceive().Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task WhenAFlightPlanIsUpdated_AndEstimatedFlightTimeIsBelowMinimum_ActivateFlightRequestIsNotSent()
     {
         // Arrange

--- a/source/Maestro.Core/Handlers/FlightPlanUpdatedHandler.cs
+++ b/source/Maestro.Core/Handlers/FlightPlanUpdatedHandler.cs
@@ -86,10 +86,12 @@ public class FlightPlanUpdatedHandler(
         if (config.DepartureAirports.Any(d => d.Identifier == record.Origin))
             return config.AutoActivateDepartures;
 
-        // Don't reactivate a flight that has already touched down. After landing the FDR
-        // continues to report Active during taxi until it transitions to STATE_FINISHED,
-        // which would otherwise re-insert a flight that a controller has just removed.
-        if (record.Position?.IsOnGround == true)
+        // Require a live position before auto-activating an arrival
+        if (record.Position is null)
+            return false;
+
+        // Don't reactivate a flight that has already touched down or not yet departed
+        if (record.Position.IsOnGround)
             return false;
 
         var landingEstimate = record.Estimates.LastOrDefault()?.Estimate;

--- a/source/Maestro.Core/Handlers/FlightPlanUpdatedHandler.cs
+++ b/source/Maestro.Core/Handlers/FlightPlanUpdatedHandler.cs
@@ -108,9 +108,11 @@ public class FlightPlanUpdatedHandler(
         if (record.State is not FlightPlanState.Active)
             return false;
 
-        // Require at least one future-dated route estimate. Once the route is fully overflown
-        // the FDR can still report Active briefly, and activating without a future estimate
-        // produces a flight whose entire trajectory is in the past.
-        return record.Estimates.Any(e => e.Estimate > now);
+        // Only auto-activate arrivals that still have a feeder fix ahead of them. A flight
+        // already inside the TMA (past the feeder fix) or filed without a feeder fix must be
+        // inserted manually, so that a flight the controller has removed cannot resurrect
+        // itself while absorbing delay on final.
+        return record.Estimates.Any(e =>
+            config.FeederFixes.Contains(e.FixIdentifier) && e.Estimate > now);
     }
 }


### PR DESCRIPTION
Fixes #195
Fixes #187

Ensure flights are only auto-activated when:
- Coupled to a radar track
- Not on the ground
- Have a Feeder Fix in the flight plan (should've been implemented, but accidentally got removed)
- Have a Feeder Fix with a **future** ETA