### PR TITLE
feat: allow editing the server URL before connecting

### DIFF
--- a/source/Maestro.Core.Tests/Mocks/MockLocalConnectionManager.cs
+++ b/source/Maestro.Core.Tests/Mocks/MockLocalConnectionManager.cs
@@ -4,7 +4,9 @@ namespace Maestro.Core.Tests.Mocks;
 
 public class MockLocalConnectionManager : IMaestroConnectionManager
 {
-    public Task<IMaestroConnection> CreateConnection(string airportIdentifier, string environment, CancellationToken cancellationToken)
+    public Uri CurrentServerUrl { get; } = new("http://localhost");
+
+    public Task<IMaestroConnection> CreateConnection(string airportIdentifier, Uri serverUrl, string environment, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/source/Maestro.Core.Tests/Mocks/MockSlaveConnectionManager.cs
+++ b/source/Maestro.Core.Tests/Mocks/MockSlaveConnectionManager.cs
@@ -14,7 +14,9 @@ public class MockSlaveConnectionManager : IMaestroConnectionManager
 
     public MockSlaveConnection Connection => _connection;
 
-    public Task<IMaestroConnection> CreateConnection(string airportIdentifier, string environment, CancellationToken cancellationToken)
+    public Uri CurrentServerUrl { get; } = new("http://localhost");
+
+    public Task<IMaestroConnection> CreateConnection(string airportIdentifier, Uri serverUrl, string environment, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/source/Maestro.Core/Connectivity/Contracts/CreateConnectionRequest.cs
+++ b/source/Maestro.Core/Connectivity/Contracts/CreateConnectionRequest.cs
@@ -2,4 +2,4 @@ using MediatR;
 
 namespace Maestro.Core.Connectivity.Contracts;
 
-public record CreateConnectionRequest(string AirportIdentifier, string Environment) : IRequest;
+public record CreateConnectionRequest(string AirportIdentifier, Uri ServerUrl, string Environment) : IRequest;

--- a/source/Maestro.Core/Connectivity/Handlers/CreateConnectionRequestHandler.cs
+++ b/source/Maestro.Core/Connectivity/Handlers/CreateConnectionRequestHandler.cs
@@ -18,6 +18,7 @@ public class CreateConnectionRequestHandler(
         {
             var connection = await connectionManager.CreateConnection(
                 request.AirportIdentifier,
+                request.ServerUrl,
                 request.Environment,
                 cancellationToken);
 

--- a/source/Maestro.Core/Connectivity/IMaestroConnectionManager.cs
+++ b/source/Maestro.Core/Connectivity/IMaestroConnectionManager.cs
@@ -2,8 +2,11 @@ namespace Maestro.Core.Connectivity;
 
 public interface IMaestroConnectionManager
 {
+    Uri CurrentServerUrl { get; }
+
     Task<IMaestroConnection> CreateConnection(
         string airportIdentifier,
+        Uri serverUrl,
         string environment,
         CancellationToken cancellationToken);
 

--- a/source/Maestro.Core/Connectivity/MaestroConnection.cs
+++ b/source/Maestro.Core/Connectivity/MaestroConnection.cs
@@ -23,6 +23,7 @@ public class MaestroConnection : IMaestroConnection, IAsyncDisposable
     readonly List<PeerInfo> _peers = new();
     readonly CancellationTokenSource _rootCancellationTokenSource = new();
     readonly ServerConfiguration _serverConfiguration;
+    readonly Uri _serverUrl;
     readonly string _airportIdentifier;
     readonly IMediator _mediator;
     readonly ISessionManager _sessionManager;
@@ -40,6 +41,7 @@ public class MaestroConnection : IMaestroConnection, IAsyncDisposable
 
     public MaestroConnection(
         ServerConfiguration serverConfiguration,
+        Uri serverUrl,
         string airportIdentifier,
         string environment,
         IMediator mediator,
@@ -47,6 +49,7 @@ public class MaestroConnection : IMaestroConnection, IAsyncDisposable
         ILogger logger)
     {
         _serverConfiguration = serverConfiguration;
+        _serverUrl = serverUrl;
         _airportIdentifier = airportIdentifier;
         Environment = environment;
 
@@ -65,7 +68,7 @@ public class MaestroConnection : IMaestroConnection, IAsyncDisposable
         var clientVersion = AssemblyVersionHelper.GetVersion(typeof(MaestroConnection).Assembly);
 
         _hubConnection = new HubConnectionBuilder()
-            .WithUrl(_serverConfiguration.Uri + $"?environment={Environment}&airportIdentifier={_airportIdentifier}&callsign={callsign}&version={clientVersion}")
+            .WithUrl(_serverUrl + $"?environment={Environment}&airportIdentifier={_airportIdentifier}&callsign={callsign}&version={clientVersion}")
             .WithServerTimeout(TimeSpan.FromSeconds(_serverConfiguration.TimeoutSeconds))
             .WithAutomaticReconnect(new InfiniteRetryPolicy())
             .WithStatefulReconnect()

--- a/source/Maestro.Core/Connectivity/MaestroConnectionManager.cs
+++ b/source/Maestro.Core/Connectivity/MaestroConnectionManager.cs
@@ -21,13 +21,17 @@ public class MaestroConnectionManager : IMaestroConnectionManager, IAsyncDisposa
         ILogger logger)
     {
         _serverConfiguration = serverConfiguration;
+        CurrentServerUrl = serverConfiguration.Uri;
         _mediator = mediator;
         _sessionManager = sessionManager;
         _logger = logger;
     }
 
+    public Uri CurrentServerUrl { get; private set; }
+
     public async Task<IMaestroConnection> CreateConnection(
         string airportIdentifier,
+        Uri serverUrl,
         string environment,
         CancellationToken cancellationToken)
     {
@@ -40,8 +44,11 @@ public class MaestroConnectionManager : IMaestroConnectionManager, IAsyncDisposa
                     $"Connection already exists for {airportIdentifier}.");
             }
 
+            CurrentServerUrl = serverUrl;
+
             var connection = new MaestroConnection(
                 _serverConfiguration,
+                serverUrl,
                 airportIdentifier,
                 environment,
                 _mediator,

--- a/source/Maestro.Plugin/Handlers/OpenConnectionWindowRequestHandler.cs
+++ b/source/Maestro.Plugin/Handlers/OpenConnectionWindowRequestHandler.cs
@@ -23,7 +23,7 @@ public class OpenConnectionWindowRequestHandler(
         windowManager.FocusOrCreateWindow(
             WindowKeys.Connection(request.AirportIdentifier),
             "Setup",
-            windowHandle => new ConnectionView(new ConnectionViewModel(request.AirportIdentifier, serverConfiguration, environment, isConnected, isReady, mediator, windowHandle, errorReporter)));
+            windowHandle => new ConnectionView(new ConnectionViewModel(request.AirportIdentifier, serverConfiguration, connectionManager.CurrentServerUrl, environment, isConnected, isReady, mediator, windowHandle, errorReporter)));
 
         return Task.CompletedTask;
     }

--- a/source/Maestro.Wpf/ViewModels/ConnectionViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/ConnectionViewModel.cs
@@ -14,6 +14,10 @@ public partial class ConnectionViewModel : ObservableObject
     readonly IErrorReporter _errorReporter;
 
     readonly string _airportIdentifier;
+    readonly Uri _defaultServerUrl;
+
+    [ObservableProperty]
+    string _serverUrl;
 
     [ObservableProperty]
     string[] _servers;
@@ -38,6 +42,7 @@ public partial class ConnectionViewModel : ObservableObject
     public ConnectionViewModel(
         string airportIdentifier,
         ServerConfiguration serverConfiguration,
+        Uri currentServerUrl,
         string environment,
         bool isConnected,
         bool isReady,
@@ -46,6 +51,8 @@ public partial class ConnectionViewModel : ObservableObject
         IErrorReporter errorReporter)
     {
         _airportIdentifier = airportIdentifier;
+        _defaultServerUrl = serverConfiguration.Uri;
+        ServerUrl = currentServerUrl.ToString();
         Servers = serverConfiguration.Environments;
         SelectedServer = !string.IsNullOrEmpty(environment) ? environment : serverConfiguration.Environments.First();
         IsConnected = isConnected;
@@ -67,7 +74,11 @@ public partial class ConnectionViewModel : ObservableObject
             }
             else
             {
-                _mediator.Send(new CreateConnectionRequest(_airportIdentifier, SelectedServer));
+                var serverUrl = string.IsNullOrWhiteSpace(ServerUrl)
+                    ? _defaultServerUrl
+                    : new Uri(ServerUrl);
+
+                _mediator.Send(new CreateConnectionRequest(_airportIdentifier, serverUrl, SelectedServer));
             }
 
             _windowHandle.Close();

--- a/source/Maestro.Wpf/ViewModels/ConnectionViewModel.cs
+++ b/source/Maestro.Wpf/ViewModels/ConnectionViewModel.cs
@@ -80,8 +80,6 @@ public partial class ConnectionViewModel : ObservableObject
 
                 _mediator.Send(new CreateConnectionRequest(_airportIdentifier, serverUrl, SelectedServer));
             }
-
-            _windowHandle.Close();
         }
         catch (Exception ex)
         {

--- a/source/Maestro.Wpf/Views/ConnectionView.xaml
+++ b/source/Maestro.Wpf/Views/ConnectionView.xaml
@@ -76,9 +76,18 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <TextBlock Grid.Row="0" Grid.Column="0" Text="Server"/>
+            <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Text="Server URL"/>
+            <TextBox
+                Grid.Row="1"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
+                Text="{Binding ServerUrl, UpdateSourceTrigger=PropertyChanged}"
+                IsEnabled="{Binding CanChangeServer}"
+                Margin="0,2,0,2" />
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Server"/>
             <ComboBox
-                Grid.Row="0"
+                Grid.Row="2"
                 Grid.Column="1"
                 ItemsSource="{Binding Servers}"
                 SelectedValue="{Binding SelectedServer, Mode=TwoWay}"


### PR DESCRIPTION
Fixes #200.

Adds a text box to the connection window for the server URL. Defaults from the configuration file, can be overridden at connect time, and the config is not modified. The last-used value persists across window opens for the lifetime of the connection manager.