### PR TITLE
fix: prevent parked departure-airport flights from auto-activating

### DIFF
--- a/docs/docs/admin-guide/02-plugin-configuration.md
+++ b/docs/docs/admin-guide/02-plugin-configuration.md
@@ -265,7 +265,7 @@ Airports:
 | `ManualInteractionState` | string | `Stable` | State after manual changes |
 | `MaximumAutoActivationLeadTimeMinutes` | integer | 120 | Flights with a landing estimate further out than this will not be auto-activated |
 | `MinimumAutoActivationFlightTimeMinutes` | integer | 25 | Flights with an estimated flight time shorter than this value will not be auto-activated |
-| `AutoActivateDepartures` | boolean | `true` | When `false`, flights from departure airports are not auto-activated |
+| `AutoActivateDepartures` | boolean | `true` | When `true`, flights from departure airports auto-activate once airborne, using the same criteria as any other arrival. When `false`, they are never auto-activated and must be inserted manually from the Pending List. |
 | `MinimumUnstableMinutes` | integer | 5 | Minimum time in Unstable state |
 | `StabilityThresholdMinutes` | integer | 25 | Minutes before ETA_FF to become Stable |
 | `FrozenThresholdMinutes` | integer | 15 | Minutes before STA to become Frozen |

--- a/docs/docs/user-guide/01-system-overview.md
+++ b/docs/docs/user-guide/01-system-overview.md
@@ -83,7 +83,7 @@ A flight is activated in vMaestro when it is added to the sequence. This can hap
 
 Flights are automatically activated when their flight plan is active in vatSys and their estimated flight time and time-to-landing fall within the configured thresholds.
 
-Flights from departure airports are activated automatically when a flight plan update is received, or can be manually activated early from the Pending List.
+Flights from departure airports are activated automatically once they are airborne, or can be manually activated early from the Pending List.
 
 ## Pending List
 

--- a/source/Maestro.Core.Tests/Handlers/FlightPlanUpdatedHandlerTests.cs
+++ b/source/Maestro.Core.Tests/Handlers/FlightPlanUpdatedHandlerTests.cs
@@ -261,10 +261,11 @@ public class FlightPlanUpdatedHandlerTests(ClockFixture clockFixture)
     }
 
     [Fact]
-    public async Task WhenAFlightPlanIsUpdated_AndFlightIsFromDepartureAirport_ActivateFlightRequestIsSent()
+    public async Task WhenAFlightPlanIsUpdated_AndFlightIsFromDepartureAirport_AndAirborneAndActive_ActivateFlightRequestIsSent()
     {
         // Arrange - YSCB is configured as a departure airport
-        // Ensure flights from departure airports auto-activate by themselves from departure airports once airborne
+        // A departure-airport flight auto-activates once it is airborne and the FDR is Active,
+        // matching the rules that apply to any other arrival.
         var airportConfiguration = GetDefaultAirportConfiguration();
         var clock = clockFixture.Instance;
         var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
@@ -279,7 +280,7 @@ public class FlightPlanUpdatedHandlerTests(ClockFixture clockFixture)
             "YSSY",
             clock.UtcNow(),
             TimeSpan.FromMinutes(35),
-            FlightPlanState.Preactive,
+            FlightPlanState.Active,
             _position,
             [new FixEstimate("RIVET", clock.UtcNow().AddMinutes(15))]);
 
@@ -290,6 +291,78 @@ public class FlightPlanUpdatedHandlerTests(ClockFixture clockFixture)
 
         // Assert
         await mediator.Received(1).Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WhenAFlightPlanIsUpdated_AndFlightIsFromDepartureAirport_AndIsOnGround_ActivateFlightRequestIsNotSent()
+    {
+        // Arrange - YSCB is configured as a departure airport
+        // A departure-airport flight that is still parked on the ground must not be auto-activated,
+        // even when AutoActivateDepartures is enabled. It stays in the Pending List until airborne.
+        var airportConfiguration = GetDefaultAirportConfiguration();
+        var clock = clockFixture.Instance;
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
+
+        var onGroundPosition = new FlightPosition(
+            new Coordinate(0, 0),
+            0,
+            VerticalTrack.Maintaining,
+            0,
+            true);
+
+        var mediator = Substitute.For<IMediator>();
+        var notification = new FlightPlanUpdatedNotification(
+            "JST425",
+            "A320",
+            AircraftCategory.Jet,
+            WakeCategory.Medium,
+            "YSCB",
+            "YSSY",
+            clock.UtcNow(),
+            TimeSpan.FromMinutes(35),
+            FlightPlanState.Active,
+            onGroundPosition,
+            [new FixEstimate("RIVET", clock.UtcNow().AddMinutes(15))]);
+
+        var handler = GetHandler(sessionManager, clock, mediator: mediator);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await mediator.DidNotReceive().Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task WhenAFlightPlanIsUpdated_AndFlightIsFromDepartureAirport_AndPositionIsNull_ActivateFlightRequestIsNotSent()
+    {
+        // Arrange - YSCB is configured as a departure airport
+        // A departure-airport flight with no coupled track (no position) must not be auto-activated.
+        var airportConfiguration = GetDefaultAirportConfiguration();
+        var clock = clockFixture.Instance;
+        var (sessionManager, _, _) = new SessionBuilder(airportConfiguration).Build();
+
+        var mediator = Substitute.For<IMediator>();
+        var notification = new FlightPlanUpdatedNotification(
+            "JST425",
+            "A320",
+            AircraftCategory.Jet,
+            WakeCategory.Medium,
+            "YSCB",
+            "YSSY",
+            clock.UtcNow(),
+            TimeSpan.FromMinutes(35),
+            FlightPlanState.Active,
+            null,
+            [new FixEstimate("RIVET", clock.UtcNow().AddMinutes(15))]);
+
+        var handler = GetHandler(sessionManager, clock, mediator: mediator);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        await mediator.DidNotReceive().Send(Arg.Any<ActivateFlightRequest>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/source/Maestro.Core/Configuration/AirportConfiguration.cs
+++ b/source/Maestro.Core/Configuration/AirportConfiguration.cs
@@ -63,8 +63,9 @@ public class AirportConfiguration
     public int MinimumAutoActivationFlightTimeMinutes { get; init; } = 25;
 
     /// <summary>
-    ///     When true, flights originating from a configured departure airport are auto-activated when the FDR state is active.
-    ///     When false, departure airport flights are not auto-activated.
+    ///     When true, flights originating from a configured departure airport are auto-activated once
+    ///     airborne, using the same criteria as any other arrival. When false, departure-airport
+    ///     flights are never auto-activated and must be inserted manually from the Pending List.
     /// </summary>
     public bool AutoActivateDepartures { get; init; } = true;
 

--- a/source/Maestro.Core/Handlers/FlightPlanUpdatedHandler.cs
+++ b/source/Maestro.Core/Handlers/FlightPlanUpdatedHandler.cs
@@ -83,14 +83,22 @@ public class FlightPlanUpdatedHandler(
 
     static bool ShouldAutoActivate(FlightDataRecord record, AirportConfiguration config, DateTimeOffset now)
     {
-        if (config.DepartureAirports.Any(d => d.Identifier == record.Origin))
-            return config.AutoActivateDepartures;
+        // AutoActivateDepartures is a hard opt-out for departure-airport flights. When disabled, a
+        // flight originating from a configured departure airport is never auto-activated and must
+        // be inserted manually from the Pending List.
+        if (config.DepartureAirports.Any(d => d.Identifier == record.Origin) &&
+            !config.AutoActivateDepartures)
+        {
+            return false;
+        }
 
-        // Require a live position before auto-activating an arrival
+        // Require a live position before auto-activating a flight
         if (record.Position is null)
             return false;
 
-        // Don't reactivate a flight that has already touched down or not yet departed
+        // Don't activate a flight that is still on the ground. Departure-airport flights stay in the
+        // Pending List until they are airborne, and arrival flights that have already touched down
+        // must not be re-inserted.
         if (record.Position.IsOnGround)
             return false;
 
@@ -108,10 +116,10 @@ public class FlightPlanUpdatedHandler(
         if (record.State is not FlightPlanState.Active)
             return false;
 
-        // Only auto-activate arrivals that still have a feeder fix ahead of them. A flight
-        // already inside the TMA (past the feeder fix) or filed without a feeder fix must be
-        // inserted manually, so that a flight the controller has removed cannot resurrect
-        // itself while absorbing delay on final.
+        // Only auto-activate flights that still have a feeder fix ahead of them. A flight already
+        // inside the TMA (past the feeder fix) or filed without a feeder fix must be inserted
+        // manually, so that a flight the controller has removed cannot resurrect itself while
+        // absorbing delay on final.
         return record.Estimates.Any(e =>
             config.FeederFixes.Contains(e.FixIdentifier) && e.Estimate > now);
     }


### PR DESCRIPTION
Ensures flights from departure airports auto-activate at the same time as any other flight.

Fixes #204
